### PR TITLE
Fix for null contextView when context/scene is unloaded and reloaded

### DIFF
--- a/Assets/scripts/strange/extensions/context/api/IContext.cs
+++ b/Assets/scripts/strange/extensions/context/api/IContext.cs
@@ -55,6 +55,9 @@ namespace strange.extensions.context.api
 		
 		/// Set and get the shared system bus for communicating across contexts
 		IDispatcher crossContextDispatcher{get;set;}
+		
+		//Get the ContextView
+		object GetContextView();
 	}
 }
 

--- a/Assets/scripts/strange/extensions/context/impl/Context.cs
+++ b/Assets/scripts/strange/extensions/context/impl/Context.cs
@@ -55,7 +55,7 @@ namespace strange.extensions.context.impl
 		
 		public Context (object view, bool autoStartup)
 		{
-			if (firstContext == null)
+			if (firstContext == null || firstContext.GetContextView() == null) //If the first context was unloaded, the contextView will be null. Assign the new context as firstContext
 			{
 				firstContext = this;
 			}
@@ -84,6 +84,11 @@ namespace strange.extensions.context.impl
 		{
 			contextView = view;
 			return this;
+		}
+		
+		virtual public object GetContextView() 
+		{ 
+			return contextView; 
 		}
 
 		/// Call this from your Root to set everything in action.


### PR DESCRIPTION
Check for null firstContext.contextView when adding a context. Null firstContext.contextView results in new/added context becoming firstContext.

Adds 
object GetContextView(); to IContext
