### PR TITLE
Make CommandBinder and Sequencer extensible

### DIFF
--- a/Assets/scripts/strange/extensions/command/impl/CommandBinder.cs
+++ b/Assets/scripts/strange/extensions/command/impl/CommandBinder.cs
@@ -159,12 +159,12 @@ namespace strange.extensions.command.impl
 			ReactTo(key, data);
 		}
 
-		new public ICommandBinding Bind<T> ()
+		new public virtual  ICommandBinding Bind<T> ()
 		{
 			return base.Bind<T> () as ICommandBinding;
 		}
 
-		new public ICommandBinding Bind (object value)
+		new public virtual ICommandBinding Bind (object value)
 		{
 			return base.Bind (value) as ICommandBinding;
 		}

--- a/Assets/scripts/strange/extensions/sequencer/impl/Sequencer.cs
+++ b/Assets/scripts/strange/extensions/sequencer/impl/Sequencer.cs
@@ -168,12 +168,12 @@ namespace strange.extensions.sequencer.impl
 			}
 		}
 
-		new public ISequenceBinding Bind<T> ()
+		new public virtual ISequenceBinding Bind<T> ()
 		{
 			return base.Bind<T> () as ISequenceBinding;
 		}
 
-		new public ISequenceBinding Bind (object value)
+		new public virtual ISequenceBinding Bind (object value)
 		{
 			return base.Bind (value) as ISequenceBinding;
 		}


### PR DESCRIPTION
Added virtual tag to CommandBinder and Sequencer to let us extend the Bind<T> and Bind(value,name) methods
