### PR TITLE
Delete unity meta file with no associated script file

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/entity/api.meta
+++ b/StrangeIoC/scripts/strange/extensions/entity/api.meta
@@ -1,4 +1,0 @@
-fileFormatVersion: 2
-guid: c5416ce0ceb8d4a5dae06bf61ce506ee
-DefaultImporter:
-  userData: 


### PR DESCRIPTION
Fixes unity import error listed in issue #6.
