### PR TITLE
Added NestedContext, and made changes to binding and injection classes t...

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/context/api/IContext.cs
+++ b/StrangeIoC/scripts/strange/extensions/context/api/IContext.cs
@@ -30,7 +30,8 @@ using strange.extensions.dispatcher.api;
 
 namespace strange.extensions.context.api
 {
-	public interface IContext : IBinder
+	// PRC: Removed IBinding parent.
+	public interface IContext /*: IBinder*/
 	{
 		/// Kick the context into action
 		IContext Start();
@@ -49,7 +50,9 @@ namespace strange.extensions.context.api
 		
 		/// Get the ContextView
 		object GetContextView();
-
+		
+		// PRC: Used to come from IBinder.
+		void OnRemove();
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/context/impl/Context.cs
+++ b/StrangeIoC/scripts/strange/extensions/context/impl/Context.cs
@@ -31,7 +31,9 @@ using strange.framework.impl;
 
 namespace strange.extensions.context.impl
 {
-	public class Context : Binder, IContext
+	// PRC: Removed Binder parent--wasn't really being used, just added OnRemove function
+	// and that's all it took.
+	public class Context : /*Binder,*/ IContext
 	{
 		/// The top of the View hierarchy.
 		/// In MVCSContext, this is your top-level GameObject
@@ -150,7 +152,10 @@ namespace strange.extensions.context.impl
 		{
 			//Override in subclasses
 		}
-
+		
+		virtual public void OnRemove()
+		{
+		}
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/context/impl/NestedContext.cs
+++ b/StrangeIoC/scripts/strange/extensions/context/impl/NestedContext.cs
@@ -1,0 +1,45 @@
+using strange.extensions.context.impl;
+using strange.extensions.command.impl;
+using UnityEngine;
+using strange.framework.impl;
+using System.Diagnostics;
+using Mobile.Utils;
+
+/** PCYR: NestedContext written to allow us to inherit bindings from
+ * other contexts like how RobotLegs does it.  I actually don't know
+ * if RL actually does it this way, but the net effect seems to be the same.
+ */
+public class NestedContext : MVCSContext
+{
+	private MVCSContext parentContext;
+	
+	public NestedContext() : base()
+	{}
+	
+	public NestedContext(MonoBehaviour view, bool autoStartup) : base(view, autoStartup)
+	{
+	}
+	
+	public void MakeChildOf(MVCSContext parent)
+	{	
+#if STRANGE_DEBUG
+		Logger.Instance.Log("NestedContext : Making ("+((Binder) injectionBinder.injector.binder).id+") a child of ("+((Binder) parent.injectionBinder.injector.binder).id+").", Logger.FilterTags.Info);
+#endif
+		
+		Assert.assert(null == parentContext, "MakeChildOf can only be called once!");
+		Assert.assert(null != parent, "parent must not be null!");
+		parentContext = parent;
+		
+		Binder injBinder = injectionBinder as Binder;
+		injBinder.SetParent(parent.injectionBinder as Binder);
+		
+		// Tried this during great nodes debug thing.  Not sure if it is necessary.
+//		Binder refBinder = injectionBinder.injector.reflector as Binder;
+//		refBinder.SetParent(parent.injectionBinder.injector.reflector as Binder);
+		
+		commandBinder.SetParent(parent.commandBinder);
+		
+		Binder dispatchBinder = (Binder) dispatcher;
+		dispatchBinder.SetParent(parent.dispatcher as Binder);
+	}
+}

--- a/StrangeIoC/scripts/strange/framework/api/IBinder.cs
+++ b/StrangeIoC/scripts/strange/framework/api/IBinder.cs
@@ -98,6 +98,9 @@ namespace strange.framework.api
 		/// Conflicts in the course of fluent binding are expected, but GetBinding
 		/// will throw an error if there are any unresolved conflicts.
 		void ResolveBinding(IBinding binding, object key);
+
+		// PRC: Added to do binding inheritance.
+		void SetParent(IBinder parent);
 	}
 }
 

--- a/StrangeIoC/scripts/strange/framework/impl/Binding.cs
+++ b/StrangeIoC/scripts/strange/framework/impl/Binding.cs
@@ -40,6 +40,12 @@ namespace strange.framework.impl
 {
 	public class Binding : IBinding
 	{
+#if STRANGE_DEBUG
+		private static int _nextId = 1;
+		public int id;
+		public Binder binder;
+#endif
+		
 		public Binder.BindingResolver resolver;
 
 		protected ISemiBinding _key;
@@ -103,6 +109,9 @@ namespace strange.framework.impl
 
 		public Binding(Binder.BindingResolver resolver)
 		{
+#if STRANGE_DEBUG
+			id = _nextId++;
+#endif		
 			this.resolver = resolver;
 
 			_key = new SemiBinding ();


### PR DESCRIPTION
Hi!  I don't mean this as a real pull request, but merely as a way of showing you something I did with strange.  Basically, I had to port a project from AS3 to C# that used RobotLegs.  It was incredibly helpful that strange was so similar to RL, and I generally thought strange was easier to use.  However, RL does one thing that strange did not: allow for nested contexts.  The cross-context thing just doesn't work the same.  So, we added our own NestedContext child of MVCSContext.  The heart of it is in Binder, where, if a binding cannot be found it checks to see if it has a parent Binder and calls getBinding on the parent.  It seems to replicate RL well enough (I don't know of any problems).  Maybe it's rare for RL users to use that system, but this project used it extensively (think thousands of contexts!)

Also, thanks for making strange, it really saved us a lot of time!
