### PR TITLE
Event Dispatcher IEvent Implementation and IEvent Command Injection

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/eventdispatcher/TestEventDispatcher.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/eventdispatcher/TestEventDispatcher.cs
@@ -89,6 +89,16 @@ namespace strange.unittests
 		}
 
 		[Test]
+		public void TestDispatchIEventArg()
+		{
+			// James
+			confirmationValue = INIT_VALUE;
+			dispatcher.AddListener(EventClass.Type.EVENT_A, oneArgumentMethod);
+			dispatcher.Dispatch(new EventClass(EventClass.Type.EVENT_A, PAYLOAD));
+			Assert.AreEqual (INIT_VALUE + PAYLOAD, confirmationValue);
+		}
+
+		[Test]
 		public void TestMultipleListeners()
 		{
 			confirmationValue = INIT_VALUE;
@@ -179,6 +189,21 @@ namespace strange.unittests
 		private void interruptMethod()
 		{
 			dispatcher.RemoveListener (SomeEnum.ONE, noArgumentsMethod);
+		}
+		
+		public class EventClass : TmEvent
+		{
+			public enum Type
+			{
+				EVENT_A,
+				EVENT_B,
+				EVENT_C
+			}
+
+			public EventClass(object type, int data) : base(type, null, data)
+			{
+
+			}
 		}
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/dispatcher/eventdispatcher/impl/EventDispatcher.cs
+++ b/StrangeIoC/scripts/strange/extensions/dispatcher/eventdispatcher/impl/EventDispatcher.cs
@@ -96,7 +96,7 @@ namespace strange.extensions.dispatcher.eventdispatcher.impl
 				isTriggeringClients = true;
 				foreach (ITriggerable trigger in triggerClients)
 				{
-					if (!trigger.Trigger(eventType, evt))
+					if (!trigger.Trigger(evt.type, evt))
 					{
 						continueDispatch = false;
 						break;
@@ -115,7 +115,7 @@ namespace strange.extensions.dispatcher.eventdispatcher.impl
 				return;
 			}
 
-			IEventBinding binding = GetBinding (eventType) as IEventBinding;
+			IEventBinding binding = GetBinding (evt.type) as IEventBinding;
 			if (binding == null)
 			{
 				internalReleaseEvent (evt);
@@ -163,7 +163,7 @@ namespace strange.extensions.dispatcher.eventdispatcher.impl
 			else if (eventType is IEvent)
 			{
 				//Client provided a full-formed event
-				retv = (IEvent)eventType;
+				retv = convertEvent(eventType);
 			}
 			else if (data == null)
 			{
@@ -173,13 +173,20 @@ namespace strange.extensions.dispatcher.eventdispatcher.impl
 			else if (data is IEvent)
 			{
 				//Client provided both an evertType and a full-formed IEvent
-				retv = (IEvent)data;
+				retv = convertEvent(data);
 			}
 			else
 			{
 				//Client provided an eventType and some data which is not a IEvent.
 				retv = createEvent (eventType, data);
 			}
+			return retv;
+		}
+
+		virtual protected IEvent convertEvent(object eventObject)
+		{
+			IEvent retv = (IEvent) eventObject;
+			if(retv.target == null) retv.target = this;
 			return retv;
 		}
 


### PR DESCRIPTION
We were using an old version of strange from the Unity Asset Store. 
We started using the IEvent inside the object (as we found you had implemented taking and re-using an IEvent which we then cast and use as type data.
When we started using the master branch it stopped working. And have added a NUnit test.

Also, just so you know we found the TestBindingAsPoolFacade seems to be referencing older code and doesn't work anymore.
