### PR TITLE
Fixed duplication mediator bug in issue #71

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -58,6 +58,7 @@ namespace strange.extensions.mediation.impl
 				switch(evt)
 				{
 					case MediationEvent.AWAKE:
+						view.registeredWithContext = true;
 						injectViewAndChildren(view);
 						mapView (view, binding);
 						break;
@@ -87,7 +88,7 @@ namespace strange.extensions.mediation.impl
 				IView iView = views[a] as IView;
 				if (iView != null)
 				{
-					if (iView.autoRegisterWithContext || iView.registeredWithContext)
+					if (iView.autoRegisterWithContext && iView.registeredWithContext)
 					{
 						continue;
 					}

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -87,7 +87,7 @@ namespace strange.extensions.mediation.impl
 				IView iView = views[a] as IView;
 				if (iView != null)
 				{
-					if (iView.autoRegisterWithContext && iView.registeredWithContext)
+					if (iView.autoRegisterWithContext || iView.registeredWithContext)
 					{
 						continue;
 					}


### PR DESCRIPTION
I didn't want to add any tests as I have no idea how you are all conducting your tests. And if you can create gameobjects etc. I'm using unity test tools. Which all run in editor scripts and work, but it can mess up your scene when you add gameobjects.

Anyways, you can see an example of the bug pre-fix here:
https://www.dropbox.com/s/5g0bqtu169qdz9t/StangeMediationBug.zip
