### PR TITLE
EventCommandBinder command constructor bug fix

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/command/TestEventCommandBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/command/TestEventCommandBinder.cs
@@ -1,0 +1,75 @@
+﻿using NUnit.Framework;
+using strange.extensions.command.api;
+using strange.extensions.command.impl;
+using strange.extensions.dispatcher.api;
+using strange.extensions.dispatcher.eventdispatcher.api;
+using strange.extensions.dispatcher.eventdispatcher.impl;
+using strange.extensions.injector.api;
+using strange.extensions.injector.impl;
+using strange.framework.api;
+
+namespace strange.unittests
+{
+    [TestFixture]
+    public class TestEventCommandBinder
+    {
+        private IInjectionBinder injectionBinder;
+        private ICommandBinder commandBinder;
+        private IEventDispatcher eventDispatcher;
+
+        [SetUp]
+        public void SetUp()
+        {
+            injectionBinder = new InjectionBinder();
+            injectionBinder.Bind<IInjectionBinder>().Bind<IInstanceProvider>().ToValue(injectionBinder);
+            injectionBinder.Bind<IEventDispatcher>().To<EventDispatcher>().ToSingleton();
+            injectionBinder.Bind<ICommandBinder>().To<EventCommandBinder>().ToSingleton();
+            commandBinder = injectionBinder.GetInstance<ICommandBinder>();
+            eventDispatcher = injectionBinder.GetInstance<IEventDispatcher>();
+            (eventDispatcher as ITriggerProvider).AddTriggerable(commandBinder as ITriggerable);
+            BadCommand.TestValue = 0;
+        }
+
+        [Test] public void TestBadConstructorCleanup()
+        {
+            commandBinder.Bind(TestEvent.TEST).To<BadCommand>();
+
+            Assert.Throws<CommandException>(delegate
+            {
+                eventDispatcher.Dispatch(TestEvent.TEST);
+                Assert.AreEqual(0,BadCommand.TestValue); //execute did not run
+            });
+
+            //Run it back, and assert that it throws a CommandException
+            //It should *NOT* throw a binder exception
+            //Recent fix to wrap createCommand with a try catch finally block fixes this previous bug.
+            Assert.Throws<CommandException>(delegate
+            {
+                eventDispatcher.Dispatch(TestEvent.TEST);
+            });
+        }
+
+        class TestEvent : IEvent
+        {
+
+            public const string TEST = "TEST";
+            public object type { get; set; }
+            public IEventDispatcher target { get; set; }
+            public object data { get; set; }
+
+        }
+        class BadCommand : EventCommand
+        {
+            public static int TestValue;
+            public BadCommand()
+            {
+                //This is nonsense, but should break horribly on GetInstance
+                injectionBinder.Bind<IEvent>().To(new TestEvent());
+            }
+            public override void Execute()
+            {
+                TestValue++;
+            }
+        }
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/command/impl/EventCommandBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/command/impl/EventCommandBinder.cs
@@ -32,7 +32,6 @@ namespace strange.extensions.command.impl
 		public EventCommandBinder ()
 		{
 		}
-
 		/// 
 		override protected ICommand createCommand(object cmd, object data)
 		{
@@ -42,25 +41,36 @@ namespace strange.extensions.command.impl
 				injectionBinder.Bind<IEvent>().ToValue(data).ToInject(false);
 			}
 
-			ICommand command = injectionBinder.GetInstance<ICommand> () as ICommand;
-			if (command == null)
+			ICommand command = injectionBinder.GetInstance<ICommand>() as ICommand;
+			try
 			{
-				string msg = "A Command ";
+				if (command == null)
+				{
+					string msg = "A Command ";
+					if (data is IEvent)
+					{
+						IEvent evt = (IEvent) data;
+						msg += "tied to event " + evt.type;
+					}
+					msg += " could not be instantiated.\nThis might be caused by a null pointer during instantiation or failing to override Execute (generally you shouldn't have constructor code in Commands).";
+					throw new CommandException(msg, CommandExceptionType.BAD_CONSTRUCTOR);
+				}
+
+				command.data = data;
+			}
+			catch (Exception)
+			{
+				throw;
+			}
+			finally
+			{
 				if (data is IEvent)
 				{
-					IEvent evt = (IEvent)data;
-					msg += "tied to event " + evt.type;
+					injectionBinder.Unbind<IEvent>();
 				}
-				msg += " could not be instantiated.\nThis might be caused by a null pointer during instantiation or failing to override Execute (generally you shouldn't have constructor code in Commands).";
-				throw new CommandException(msg, CommandExceptionType.BAD_CONSTRUCTOR);
+				injectionBinder.Unbind<ICommand>();
 			}
-
-			command.data = data;
-			if (data is IEvent)
-			{
-				injectionBinder.Unbind<IEvent>();
-			}
-			injectionBinder.Unbind<ICommand> ();
+			
 			return command;
 		}
 


### PR DESCRIPTION
fix bug in event command binder preventing graceful unbinding of ICommand and IEvent
