### PR TITLE
Polymorphic signal command injections and small event command binder fix

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/command/TestEventCommandBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/command/TestEventCommandBinder.cs
@@ -1,0 +1,75 @@
+﻿using NUnit.Framework;
+using strange.extensions.command.api;
+using strange.extensions.command.impl;
+using strange.extensions.dispatcher.api;
+using strange.extensions.dispatcher.eventdispatcher.api;
+using strange.extensions.dispatcher.eventdispatcher.impl;
+using strange.extensions.injector.api;
+using strange.extensions.injector.impl;
+using strange.framework.api;
+
+namespace strange.unittests
+{
+    [TestFixture]
+    public class TestEventCommandBinder
+    {
+        private IInjectionBinder injectionBinder;
+        private ICommandBinder commandBinder;
+        private IEventDispatcher eventDispatcher;
+
+        [SetUp]
+        public void SetUp()
+        {
+            injectionBinder = new InjectionBinder();
+            injectionBinder.Bind<IInjectionBinder>().Bind<IInstanceProvider>().ToValue(injectionBinder);
+            injectionBinder.Bind<IEventDispatcher>().To<EventDispatcher>().ToSingleton();
+            injectionBinder.Bind<ICommandBinder>().To<EventCommandBinder>().ToSingleton();
+            commandBinder = injectionBinder.GetInstance<ICommandBinder>();
+            eventDispatcher = injectionBinder.GetInstance<IEventDispatcher>();
+            (eventDispatcher as ITriggerProvider).AddTriggerable(commandBinder as ITriggerable);
+            BadCommand.TestValue = 0;
+        }
+
+        [Test] public void TestBadConstructorCleanup()
+        {
+            commandBinder.Bind(TestEvent.TEST).To<BadCommand>();
+
+            Assert.Throws<CommandException>(delegate
+            {
+                eventDispatcher.Dispatch(TestEvent.TEST);
+                Assert.AreEqual(0,BadCommand.TestValue); //execute did not run
+            });
+
+            //Run it back, and assert that it throws a CommandException
+            //It should *NOT* throw a binder exception
+            //Recent fix to wrap createCommand with a try catch finally block fixes this previous bug.
+            Assert.Throws<CommandException>(delegate
+            {
+                eventDispatcher.Dispatch(TestEvent.TEST);
+            });
+        }
+
+        class TestEvent : IEvent
+        {
+
+            public const string TEST = "TEST";
+            public object type { get; set; }
+            public IEventDispatcher target { get; set; }
+            public object data { get; set; }
+
+        }
+        class BadCommand : EventCommand
+        {
+            public static int TestValue;
+            public BadCommand()
+            {
+                //This is nonsense, but should break horribly on GetInstance
+                injectionBinder.Bind<IEvent>().To(new TestEvent());
+            }
+            public override void Execute()
+            {
+                TestValue++;
+            }
+        }
+    }
+}

--- a/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignalCommandBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignalCommandBinder.cs
@@ -1,12 +1,13 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
+using strange.extensions.command.api;
+using strange.extensions.command.impl;
 using strange.extensions.injector.api;
 using strange.extensions.injector.impl;
-using strange.extensions.command.impl;
-using strange.extensions.command.api;
-using strange.extensions.signal.impl;
 using strange.extensions.signal.api;
+using strange.extensions.signal.impl;
 using strange.framework.api;
+using System;
+using System.Collections.Generic;
 
 namespace strange.unittests
 {
@@ -15,314 +16,379 @@ namespace strange.unittests
 	public class TestSignalCommandBinder
 	{
 
-        IInjectionBinder injectionBinder;
-        ICommandBinder commandBinder;
+		IInjectionBinder injectionBinder;
+		ICommandBinder commandBinder;
 
-        [SetUp]
-        public void SetUp()
-        {
-            injectionBinder = new InjectionBinder();
+		[SetUp]
+		public void SetUp()
+		{
+			injectionBinder = new InjectionBinder();
 			injectionBinder.Bind<IInjectionBinder>().Bind<IInstanceProvider>().ToValue(injectionBinder);
-            injectionBinder.Bind<ICommandBinder>().To<SignalCommandBinder>().ToSingleton();
-            commandBinder = injectionBinder.GetInstance<ICommandBinder>() as ICommandBinder;
-            injectionBinder.Bind<TestModel>().ToSingleton();
-        }
+			injectionBinder.Bind<ICommandBinder>().To<SignalCommandBinder>().ToSingleton();
+			commandBinder = injectionBinder.GetInstance<ICommandBinder>() as ICommandBinder;
+			injectionBinder.Bind<TestModel>().ToSingleton();
+		}
 
-        [Test]
-        public void TestNoArgs()
-        {
-            commandBinder.Bind<NoArgSignal>().To<NoArgSignalCommand>();
+		[Test]
+		public void TestNoArgs()
+		{
+			commandBinder.Bind<NoArgSignal>().To<NoArgSignalCommand>();
 
-            TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.AreEqual(testModel.StoredValue, 0);
+			TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.AreEqual(testModel.StoredValue, 0);
 
-            NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
-            signal.Dispatch();
-            Assert.AreEqual(testModel.StoredValue, 1);
-        }
+			NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
+			signal.Dispatch();
+			Assert.AreEqual(testModel.StoredValue, 1);
+		}
 
 
-        [Test]
-        public void TestOnce()
-        {
-            
-            commandBinder.Bind<NoArgSignal>().To<NoArgSignalCommand>().Once();
+		[Test]
+		public void TestOnce()
+		{
+			
+			commandBinder.Bind<NoArgSignal>().To<NoArgSignalCommand>().Once();
 
-            TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
+			TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
 
-            Assert.AreEqual(testModel.StoredValue, 0);
+			Assert.AreEqual(testModel.StoredValue, 0);
 
 
-            NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
-            signal.Dispatch();
-            Assert.AreEqual(testModel.StoredValue, 1);
+			NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
+			signal.Dispatch();
+			Assert.AreEqual(testModel.StoredValue, 1);
 
-            signal.Dispatch();
-            Assert.AreEqual(testModel.StoredValue, 1); //Should do nothing
+			signal.Dispatch();
+			Assert.AreEqual(testModel.StoredValue, 1); //Should do nothing
 
-        }
+		}
 
-        [Test]
-        public void TestMultiple()
-        {
-            commandBinder.Bind<NoArgSignal>().To<NoArgSignalCommand>().To<NoArgSignalCommandTwo>();
+		[Test]
+		public void TestMultiple()
+		{
+			commandBinder.Bind<NoArgSignal>().To<NoArgSignalCommand>().To<NoArgSignalCommandTwo>();
 
-            TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
+			TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
 
-            Assert.AreEqual(0,testModel.StoredValue);
-            NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
+			Assert.AreEqual(0,testModel.StoredValue);
+			NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
 
-            signal.Dispatch();
-            Assert.AreEqual(1, testModel.StoredValue); //first command gives 1, second gives 2
-            Assert.AreEqual(2, testModel.SecondaryValue); //first command gives 1, second gives 2
-        }
+			signal.Dispatch();
+			Assert.AreEqual(1, testModel.StoredValue); //first command gives 1, second gives 2
+			Assert.AreEqual(2, testModel.SecondaryValue); //first command gives 1, second gives 2
+		}
 
 
-        [Test]
-        public void TestOneArg()
-        {
-            commandBinder.Bind<OneArgSignal>().To<OneArgSignalCommand>();
+		[Test]
+		public void TestOneArg()
+		{
+			commandBinder.Bind<OneArgSignal>().To<OneArgSignalCommand>();
 
-            TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
+			TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
 
-            Assert.AreEqual(0, testModel.StoredValue);
-            OneArgSignal signal = injectionBinder.GetInstance<OneArgSignal>() as OneArgSignal;
+			Assert.AreEqual(0, testModel.StoredValue);
+			OneArgSignal signal = injectionBinder.GetInstance<OneArgSignal>() as OneArgSignal;
 
-            int injectedValue = 100;
-            signal.Dispatch(injectedValue);
-            Assert.AreEqual(injectedValue, testModel.StoredValue);
-        }
+			int injectedValue = 100;
+			signal.Dispatch(injectedValue);
+			Assert.AreEqual(injectedValue, testModel.StoredValue);
+		}
 
-        [Test]
-        public void TestTwoArgs()
-        {
-            commandBinder.Bind<TwoArgSignal>().To<TwoArgSignalCommand>();
+		[Test]
+		public void TestTwoArgs()
+		{
+			commandBinder.Bind<TwoArgSignal>().To<TwoArgSignalCommand>();
 
-            TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
+			TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
 
-            Assert.AreEqual(0, testModel.StoredValue);
-            TwoArgSignal signal = injectionBinder.GetInstance<TwoArgSignal>() as TwoArgSignal;
+			Assert.AreEqual(0, testModel.StoredValue);
+			TwoArgSignal signal = injectionBinder.GetInstance<TwoArgSignal>() as TwoArgSignal;
 
-            int injectedValue = 100;
-            bool injectedBool = true;
-            signal.Dispatch(injectedValue, injectedBool); //true should be adding
-            Assert.AreEqual(injectedValue, testModel.StoredValue); 
+			int injectedValue = 100;
+			bool injectedBool = true;
+			signal.Dispatch(injectedValue, injectedBool); //true should be adding
+			Assert.AreEqual(injectedValue, testModel.StoredValue); 
 
-            injectedBool = false;
-            signal.Dispatch(injectedValue, injectedBool); //false should be subtracting
-            Assert.AreEqual(0, testModel.StoredValue); //first command gives 1, second gives 2
-        }
-
-        [Test]
-        public void TestTwoArgsSameType()
-        {
-            commandBinder.Bind<TwoArgSameTypeSignal>().To<TwoArgSameTypeSignalCommand>();
-
-            TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
-
-            Assert.AreEqual(0, testModel.StoredValue);
-            TwoArgSameTypeSignal signal = injectionBinder.GetInstance<TwoArgSameTypeSignal>() as TwoArgSameTypeSignal;
-
-            int injectedValue = 100;
-            int secondInjectedValue = 200;
-            TestDelegate testDelegate = delegate
-            {
-                signal.Dispatch(injectedValue, secondInjectedValue); 
-            };
-            SignalException ex = Assert.Throws<SignalException>(testDelegate);
-            Assert.AreEqual(ex.type, SignalExceptionType.COMMAND_VALUE_CONFLICT);
-        }
-
-
-        [Test]
-        public void TestSequence()
-        {
-            //CommandWithInjection requires an ISimpleInterface
-            injectionBinder.Bind<ISimpleInterface>().To<SimpleInterfaceImplementer>().ToSingleton();
-
-            //Bind the trigger to the command
-            commandBinder.Bind<NoArgSignal>().To<CommandWithInjection>().To<CommandWithExecute>().To<CommandWithoutExecute>().InSequence();
-
-            TestDelegate testDelegate = delegate
-            {
-                NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
-                signal.Dispatch();
-            };
-
-            //That the exception is thrown demonstrates that the last command ran
-            CommandException ex = Assert.Throws<CommandException>(testDelegate);
-            Assert.AreEqual(ex.type, CommandExceptionType.EXECUTE_OVERRIDE);
-
-            //That the value is 100 demonstrates that the first command ran
-            ISimpleInterface instance = injectionBinder.GetInstance<ISimpleInterface>() as ISimpleInterface;
-            Assert.AreEqual(100, instance.intValue);
-        }
-
-
-        [Test]
-        public void TestSequenceTwo()
-        {
-            //Slightly different test to be thorough
-
-            //Bind the trigger to the command
-            commandBinder.Bind<TwoArgSignal>().To<TwoArgSignalCommand>().To<TwoArgSignalCommandTwo>().To<TwoArgSignalCommandThree>().InSequence();
-            TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
-            int intValue = 1;
-            bool boolValue = true;
-
-            TestDelegate testDelegate = delegate
-            {
-                TwoArgSignal signal = injectionBinder.GetInstance<TwoArgSignal>() as TwoArgSignal;
-                signal.Dispatch(intValue, boolValue);
-            };
-
-            Assert.Throws<TestPassedException>(testDelegate);
-            int intendedValue = 2; //intValue twice (addition because of bool == true)
-            Assert.AreEqual(intendedValue, testModel.StoredValue);
-        }
-
-        [Test]
-        public void TestInterruptedSequence()
-        {
-            //CommandWithInjection requires an ISimpleInterface
-            injectionBinder.Bind<ISimpleInterface>().To<SimpleInterfaceImplementer>().ToSingleton();
-
-            //Bind the trigger to the command
-            commandBinder.Bind <NoArgSignal>().To<CommandWithInjection>().To<FailCommand>().To<CommandWithoutExecute>().InSequence();
-
-            TestDelegate testDelegate = delegate
-            {
-                NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
-                signal.Dispatch();
-            };
-
-            //That the exception is not thrown demonstrates that the last command was interrupted
-            Assert.DoesNotThrow(testDelegate);
-
-            //That the value is 100 demonstrates that the first command ran
-            ISimpleInterface instance = injectionBinder.GetInstance<ISimpleInterface>() as ISimpleInterface;
-            Assert.AreEqual(100, instance.intValue);
-        }
-
-
-        class TestModel
-        {
-            public int StoredValue = 0;
-            public int SecondaryValue = 0;
-        }
-
-        class NoArgSignal : Signal { }
-        class OneArgSignal : Signal<int> { }
-        class TwoArgSignal : Signal<int, bool> { }
-        class TwoArgSameTypeSignal : Signal<int, int> { }
-
-
-        class NoArgSignalCommand: Command
-        {
-            [Inject]
-            public TestModel TestModel { get; set; }
-
-            public override void Execute()
-            {
-                TestModel.StoredValue++;
-            }
-        }
-
-        class NoArgSignalCommandTwo : Command
-        {
-            [Inject]
-            public TestModel TestModel { get; set; }
-
-            public override void Execute()
-            {
-                TestModel.SecondaryValue += 2;
-            }
-        }
-
-        class OneArgSignalCommand : Command
-        {
-            [Inject]
-            public int injectedValue { get; set; }
-
-            [Inject]
-            public TestModel TestModel { get; set; }
-
-            public override void Execute()
-            {
-                TestModel.StoredValue += injectedValue;
-            }
-        }
-
-        class TwoArgSignalCommand : Command
-        {
-            [Inject]
-            public int injectedValue { get; set; }
-            [Inject]
-            public bool injectedBool { get; set; }
-            [Inject]
-            public TestModel TestModel { get; set; }
-
-            public override void Execute()
-            {
-                if (injectedBool)
-                    TestModel.StoredValue += injectedValue;
-                else
-                    TestModel.StoredValue -= injectedValue;
-            }
-        }
-
-        class TwoArgSignalCommandTwo : Command
-        {
-            [Inject]
-            public int injectedValue { get; set; }
-            [Inject]
-            public bool injectedBool { get; set; }
-            [Inject]
-            public TestModel TestModel { get; set; }
-
-            public override void Execute()
-            {
-                if (injectedBool)
-                    TestModel.StoredValue += injectedValue;
-                else
-                    TestModel.StoredValue -= injectedValue;
-            }
-        }
-
-        class TwoArgSignalCommandThree : Command
-        {
-            [Inject]
-            public int injectedValue { get; set; }
-            [Inject]
-            public bool injectedBool { get; set; }
-            [Inject]
-            public TestModel TestModel { get; set; }
-
-            public override void Execute()
-            {
-                throw new TestPassedException("Test Passed");
-            }
-        }
-
-        class TwoArgSameTypeSignalCommand : Command
-        {
-            [Inject]
-            public int injectedValue { get; set; }
-            [Inject]
-            public int secondInjectedValue { get; set; }
-            [Inject]
-            public TestModel TestModel { get; set; }
-
-            public override void Execute()
-            {
-                //This should never be run
-                throw new Exception("This should not be reached");
-            }
-        }
-
-        class TestPassedException : Exception
-        {
-            public TestPassedException(string str) : base(str) { }
-        }
+			injectedBool = false;
+			signal.Dispatch(injectedValue, injectedBool); //false should be subtracting
+			Assert.AreEqual(0, testModel.StoredValue); //first command gives 1, second gives 2
+		}
+
+		[Test]
+		public void TestTwoArgsSameType()
+		{
+			commandBinder.Bind<TwoArgSameTypeSignal>().To<TwoArgSameTypeSignalCommand>();
+
+			TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
+
+			Assert.AreEqual(0, testModel.StoredValue);
+			TwoArgSameTypeSignal signal = injectionBinder.GetInstance<TwoArgSameTypeSignal>() as TwoArgSameTypeSignal;
+
+			int injectedValue = 100;
+			int secondInjectedValue = 200;
+			TestDelegate testDelegate = delegate
+			{
+				signal.Dispatch(injectedValue, secondInjectedValue); 
+			};
+			SignalException ex = Assert.Throws<SignalException>(testDelegate);
+			Assert.AreEqual(ex.type, SignalExceptionType.COMMAND_VALUE_CONFLICT);
+		}
+
+
+		[Test]
+		public void TestSequence()
+		{
+			//CommandWithInjection requires an ISimpleInterface
+			injectionBinder.Bind<ISimpleInterface>().To<SimpleInterfaceImplementer>().ToSingleton();
+
+			//Bind the trigger to the command
+			commandBinder.Bind<NoArgSignal>().To<CommandWithInjection>().To<CommandWithExecute>().To<CommandWithoutExecute>().InSequence();
+
+			TestDelegate testDelegate = delegate
+			{
+				NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
+				signal.Dispatch();
+			};
+
+			//That the exception is thrown demonstrates that the last command ran
+			CommandException ex = Assert.Throws<CommandException>(testDelegate);
+			Assert.AreEqual(ex.type, CommandExceptionType.EXECUTE_OVERRIDE);
+
+			//That the value is 100 demonstrates that the first command ran
+			ISimpleInterface instance = injectionBinder.GetInstance<ISimpleInterface>() as ISimpleInterface;
+			Assert.AreEqual(100, instance.intValue);
+		}
+
+
+		[Test]
+		public void TestSequenceTwo()
+		{
+			//Slightly different test to be thorough
+
+			//Bind the trigger to the command
+			commandBinder.Bind<TwoArgSignal>().To<TwoArgSignalCommand>().To<TwoArgSignalCommandTwo>().To<TwoArgSignalCommandThree>().InSequence();
+			TestModel testModel = injectionBinder.GetInstance<TestModel>() as TestModel;
+			int intValue = 1;
+			bool boolValue = true;
+
+			TestDelegate testDelegate = delegate
+			{
+				TwoArgSignal signal = injectionBinder.GetInstance<TwoArgSignal>() as TwoArgSignal;
+				signal.Dispatch(intValue, boolValue);
+			};
+
+			Assert.Throws<TestPassedException>(testDelegate);
+			int intendedValue = 2; //intValue twice (addition because of bool == true)
+			Assert.AreEqual(intendedValue, testModel.StoredValue);
+		}
+
+		[Test]
+		public void TestInterruptedSequence()
+		{
+			//CommandWithInjection requires an ISimpleInterface
+			injectionBinder.Bind<ISimpleInterface>().To<SimpleInterfaceImplementer>().ToSingleton();
+
+			//Bind the trigger to the command
+			commandBinder.Bind <NoArgSignal>().To<CommandWithInjection>().To<FailCommand>().To<CommandWithoutExecute>().InSequence();
+
+			TestDelegate testDelegate = delegate
+			{
+				NoArgSignal signal = injectionBinder.GetInstance<NoArgSignal>() as NoArgSignal;
+				signal.Dispatch();
+			};
+
+			//That the exception is not thrown demonstrates that the last command was interrupted
+			Assert.DoesNotThrow(testDelegate);
+
+			//That the value is 100 demonstrates that the first command ran
+			ISimpleInterface instance = injectionBinder.GetInstance<ISimpleInterface>() as ISimpleInterface;
+			Assert.AreEqual(100, instance.intValue);
+		}
+
+		internal static ConditionalAction conditionalAction;
+		[Test]
+		public void TestDualPolymorphicInjectionSequence()
+		{
+			conditionalAction = null;
+			commandBinder.Bind<ConditionalActionSignal>()
+				.To<CheckConditionsCommand>()
+				.To<DoActionCommand>()
+				.InSequence();
+
+			ConditionalActionSignal signal = injectionBinder.GetInstance<ConditionalActionSignal>();
+			conditionalAction = new ConditionalAction();
+			signal.Dispatch(conditionalAction);
+			//Dispatch signal command binder
+
+		}
+
+		class TestModel
+		{
+			public int StoredValue = 0;
+			public int SecondaryValue = 0;
+		}
+
+		class NoArgSignal : Signal { }
+		class OneArgSignal : Signal<int> { }
+		class TwoArgSignal : Signal<int, bool> { }
+		class TwoArgSameTypeSignal : Signal<int, int> { }
+
+
+		class NoArgSignalCommand: Command
+		{
+			[Inject]
+			public TestModel TestModel { get; set; }
+
+			public override void Execute()
+			{
+				TestModel.StoredValue++;
+			}
+		}
+
+		class NoArgSignalCommandTwo : Command
+		{
+			[Inject]
+			public TestModel TestModel { get; set; }
+
+			public override void Execute()
+			{
+				TestModel.SecondaryValue += 2;
+			}
+		}
+
+		class OneArgSignalCommand : Command
+		{
+			[Inject]
+			public int injectedValue { get; set; }
+
+			[Inject]
+			public TestModel TestModel { get; set; }
+
+			public override void Execute()
+			{
+				TestModel.StoredValue += injectedValue;
+			}
+		}
+
+		class TwoArgSignalCommand : Command
+		{
+			[Inject]
+			public int injectedValue { get; set; }
+			[Inject]
+			public bool injectedBool { get; set; }
+			[Inject]
+			public TestModel TestModel { get; set; }
+
+			public override void Execute()
+			{
+				if (injectedBool)
+					TestModel.StoredValue += injectedValue;
+				else
+					TestModel.StoredValue -= injectedValue;
+			}
+		}
+
+		class TwoArgSignalCommandTwo : Command
+		{
+			[Inject]
+			public int injectedValue { get; set; }
+			[Inject]
+			public bool injectedBool { get; set; }
+			[Inject]
+			public TestModel TestModel { get; set; }
+
+			public override void Execute()
+			{
+				if (injectedBool)
+					TestModel.StoredValue += injectedValue;
+				else
+					TestModel.StoredValue -= injectedValue;
+			}
+		}
+
+		class TwoArgSignalCommandThree : Command
+		{
+			[Inject]
+			public int injectedValue { get; set; }
+			[Inject]
+			public bool injectedBool { get; set; }
+			[Inject]
+			public TestModel TestModel { get; set; }
+
+			public override void Execute()
+			{
+				throw new TestPassedException("Test Passed");
+			}
+		}
+
+		class TwoArgSameTypeSignalCommand : Command
+		{
+			[Inject]
+			public int injectedValue { get; set; }
+			[Inject]
+			public int secondInjectedValue { get; set; }
+			[Inject]
+			public TestModel TestModel { get; set; }
+
+			public override void Execute()
+			{
+				//This should never be run
+				throw new Exception("This should not be reached");
+			}
+		}
+
+		class TestPassedException : Exception
+		{
+			public TestPassedException(string str) : base(str) { }
+		}
+
+
+
+#region Polymorphic SCB test
+		public interface IConditional
+		{
+			List<string> Conditions { get; }
+		}
+
+		public interface IAction
+		{
+			void DoStuff();
+		}
+
+		public class ConditionalAction : IConditional, IAction
+		{
+			public List<string> Conditions { get; private set; }
+			public void DoStuff()
+			{
+			}
+		}
+
+		public class CheckConditionsCommand : Command
+		{
+			[Inject]
+			public IConditional conditional { get; set; }
+
+			public override void Execute()
+			{
+				Assert.AreEqual(conditional, conditionalAction);
+			}
+		}
+
+		public class DoActionCommand : Command
+		{
+			[Inject]
+			public IAction action { get; set; }
+
+			public override void Execute()
+			{
+				Assert.AreEqual(action, conditionalAction);
+			}
+		}
+
+		public class ConditionalActionSignal : Signal<ConditionalAction> {}
 	}
+
+	#endregion
+
+
 }

--- a/StrangeIoC/scripts/strange/extensions/command/impl/EventCommandBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/command/impl/EventCommandBinder.cs
@@ -32,7 +32,6 @@ namespace strange.extensions.command.impl
 		public EventCommandBinder ()
 		{
 		}
-
 		/// 
 		override protected ICommand createCommand(object cmd, object data)
 		{
@@ -42,25 +41,36 @@ namespace strange.extensions.command.impl
 				injectionBinder.Bind<IEvent>().ToValue(data).ToInject(false);
 			}
 
-			ICommand command = injectionBinder.GetInstance<ICommand> () as ICommand;
-			if (command == null)
+			ICommand command = injectionBinder.GetInstance<ICommand>() as ICommand;
+			try
 			{
-				string msg = "A Command ";
+				if (command == null)
+				{
+					string msg = "A Command ";
+					if (data is IEvent)
+					{
+						IEvent evt = (IEvent) data;
+						msg += "tied to event " + evt.type;
+					}
+					msg += " could not be instantiated.\nThis might be caused by a null pointer during instantiation or failing to override Execute (generally you shouldn't have constructor code in Commands).";
+					throw new CommandException(msg, CommandExceptionType.BAD_CONSTRUCTOR);
+				}
+
+				command.data = data;
+			}
+			catch (Exception)
+			{
+				throw;
+			}
+			finally
+			{
 				if (data is IEvent)
 				{
-					IEvent evt = (IEvent)data;
-					msg += "tied to event " + evt.type;
+					injectionBinder.Unbind<IEvent>();
 				}
-				msg += " could not be instantiated.\nThis might be caused by a null pointer during instantiation or failing to override Execute (generally you shouldn't have constructor code in Commands).";
-				throw new CommandException(msg, CommandExceptionType.BAD_CONSTRUCTOR);
+				injectionBinder.Unbind<ICommand>();
 			}
-
-			command.data = data;
-			if (data is IEvent)
-			{
-				injectionBinder.Unbind<IEvent>();
-			}
-			injectionBinder.Unbind<ICommand> ();
+			
 			return command;
 		}
 

--- a/StrangeIoC/scripts/strange/extensions/signal/api/SignalExceptionType.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/api/SignalExceptionType.cs
@@ -30,5 +30,8 @@ namespace strange.extensions.signal.api
 
 		/// SignalCommandBinder attempted to bind a null value from a signal to a Command
 		COMMAND_NULL_INJECTION,
+
+		//Multiple assignable inject properties were found
+		AMBIGUOUS_VALUE_BINDING,
 	}
 }


### PR DESCRIPTION
This is two command-related improvements.

The first is a (sorely needed) test and exception handling for EventCommandBinder. Pretty straightforward, and should shine a light on issues which previously were being eaten but causing other direct binding issues.

The second is a first-pass on Polymorphic signal command bindings.

Step One: Dispatch a signal with a payload value of Type T which implements U
Step Two: Create a command which has a property of interface U
Step Three: Properly inject value of Type T in to property of interface U

This goes for multiple interfaces, of course. So if you implement U,V,W,X,Y,Z one of those will be assignable from T, and will be bound.

If more than one interface is found, we will throw a SignalExceptionType.AMBIGUOUS_VALUE_BINDING
This is to avoid weird ambiguity issues which might crop up. For instance, if we Dispatch a signal with a payload of types:

public MySignal : Signal<One,Two>
public OtherSignal : Signal<Two,One>

public class One : U,V
public class Two : V,W

in to a command with injections

[Inject]
public U MyFirstInjection { get; set; }

[Inject]
public V MySecondInjection { get; set; }

Our ordering could result in a success or failure. If we dispatch the types in order <One,Two>, U would be assigned to One, and V would be assigned to Two. However, if we dispatched in order <Two, One>, we would assign U to Two and have nothing to assign One to, and result in a binding failure.  It's not an impossible problem to fix, but there are a number of ambiguous states which could arise, and this handles those abruptly.

Most importantly, I am concerned by the performance implications, and hope to utilize the ReflectionBinder  for a new version of this. Using reflection at runtime like this with a high load of commands would be a rather dreadful decision.

In any case, I've written a test to prove it, and invite anyone to comment and reply how to make it better. This is just a couple hours work, so hopefully we can improve it and get it live.