### PR TITLE
Prevent AddListener from adding the same delegate

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignal.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignal.cs
@@ -1,11 +1,13 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
 using strange.extensions.signal.impl;
 
 namespace strange.unittests
 {
     [TestFixture()]
-	public class TestSignal
-	{
+    public class TestSignal
+    {
 
         [SetUp]
         public void SetUp()
@@ -18,6 +20,7 @@ namespace strange.unittests
         private int testIntTwo = 2;
         private int testIntThree = 3;
         private int testIntFour = 4;
+        private int intToIncrement;
 
         [Test]
         public void TestNoArgSignal()
@@ -138,52 +141,125 @@ namespace strange.unittests
         }
 
         [Test]
+        public void GetTypes_ThreeType_ExpectsTypesReturnedInList()
+        {
+            Signal<int, string, float> signal = new Signal<int, string, float>();
+
+            var actual = signal.GetTypes();
+
+            var expected = this.GetThreeExpectedTypes();
+            Assert.AreEqual(expected, actual);
+        }
+
+        private IList<Type> GetThreeExpectedTypes()
+        {
+            var expected = new List<Type>();
+            expected.Add(typeof(int));
+            expected.Add(typeof(string));
+            expected.Add(typeof(float));
+            return expected;
+        }
+
+        [Test]
+        public void GetTypes_FourType_ExpectsTypesReturnedInList()
+        {
+            Signal<int, string, float, Signal> signal = new Signal<int, string, float, Signal>();
+
+            var actual = signal.GetTypes();
+
+            var expected = this.GetThreeExpectedTypes();
+            expected.Add(typeof(Signal));
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void AddListener_SignalWithNoTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
         {
             Signal signal = new Signal();
-            simpleInt = 0;
-
+            intToIncrement = 0;
             signal.AddListener(SimpleSignalCallback);
             signal.AddListener(SimpleSignalCallback);
 
             signal.Dispatch();
 
-            Assert.AreEqual(1, simpleInt);
+            Assert.AreEqual(1, intToIncrement);
         }
 
-        private int simpleInt;
+        [Test]
+        public void AddOnce_SignalWithNoTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+        {
+            Signal signal = new Signal();
+            intToIncrement = 0;
+            signal.AddOnce(SimpleSignalCallback);
+            signal.AddOnce(SimpleSignalCallback);
+
+            signal.Dispatch();
+
+            Assert.AreEqual(1, intToIncrement);
+        }
+
         private void SimpleSignalCallback()
         {
-            simpleInt++;
+            intToIncrement++;
         }
 
         [Test]
         public void AddListener_SignalWithOneTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
         {
             Signal<int> signal = new Signal<int>();
-            simpleInt = 1;
-
+            testInt = 42;
             signal.AddListener(OneArgSignalCallback);
             signal.AddListener(OneArgSignalCallback);
 
-            signal.Dispatch(simpleInt);
+            signal.Dispatch(testInt);
 
-            Assert.AreEqual(1, testValue);
+            Assert.AreEqual(testInt, testValue);
+        }
+
+        [Test]
+        public void AddOnce_SignalWithOneTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+        {
+            Signal<int> signal = new Signal<int>();
+            testInt = 42;
+            signal.AddOnce(OneArgSignalCallback);
+            signal.AddOnce(OneArgSignalCallback);
+
+            signal.Dispatch(testInt);
+
+            Assert.AreEqual(testInt, testValue);
         }
 
         [Test]
         public void AddListener_SignalWithTwoTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
         {
-            Signal<int,int> signal = new Signal<int,int>();
-            int firstInt = 1;
-            int secondInt = 2;
-
+            Signal<int, int> signal = new Signal<int, int>();
+            this.CreateTwoInts();
             signal.AddListener(TwoArgCallback);
             signal.AddListener(TwoArgCallback);
 
-            signal.Dispatch(firstInt, secondInt);
-            int expected = firstInt + secondInt;
+            signal.Dispatch(testInt, testIntTwo);
+
+            int expected = this.GetTwoIntExpected();
             Assert.AreEqual(expected, this.testValue);
+        }
+
+        [Test]
+        public void AddOnce_SignalWithTwoTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+        {
+            Signal<int, int> signal = new Signal<int, int>();
+            this.CreateTwoInts();
+            signal.AddOnce(TwoArgCallback);
+            signal.AddOnce(TwoArgCallback);
+
+            signal.Dispatch(testInt, testIntTwo);
+
+            int expected = this.GetTwoIntExpected();
+            Assert.AreEqual(expected, this.testValue);
+        }
+
+        private int GetTwoIntExpected()
+        {
+            return testInt + testIntTwo;
         }
 
         private void TwoArgCallback(int arg1, int arg2)
@@ -194,17 +270,29 @@ namespace strange.unittests
         [Test]
         public void AddListener_SignalWithThreeTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
         {
-            Signal<int,int,int> signal = new Signal<int, int, int>();
-            int firstInt = 1;
-            int secondInt = 2;
-            int thirdInt = 3;
-
+            Signal<int, int, int> signal = new Signal<int, int, int>();
+            this.CreateThreeInts();
             signal.AddListener(ThreeArgCallback);
             signal.AddListener(ThreeArgCallback);
 
-            signal.Dispatch(firstInt, secondInt, thirdInt);
-            int expected = firstInt + secondInt + thirdInt;
+            signal.Dispatch(testInt, testIntTwo, testIntThree);
 
+            int expected = this.GetThreeIntExpected();
+            Assert.AreEqual(expected, this.testValue);
+
+        }
+
+        [Test]
+        public void AddOnce_SignalWithThreeTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+        {
+            Signal<int, int, int> signal = new Signal<int, int, int>();
+            this.CreateThreeInts();
+            signal.AddOnce(ThreeArgCallback);
+            signal.AddOnce(ThreeArgCallback);
+
+            signal.Dispatch(testInt, testIntTwo, testIntThree);
+
+            int expected = this.GetThreeIntExpected();
             Assert.AreEqual(expected, this.testValue);
 
         }
@@ -214,23 +302,66 @@ namespace strange.unittests
             this.testValue += arg1 + arg2 + arg3;
         }
 
+        private int GetThreeIntExpected()
+        {
+            return this.GetTwoIntExpected() + testIntThree;
+        }
+
         [Test]
         public void AddListener_SignalWithFourTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
         {
             Signal<int, int, int, int> signal = new Signal<int, int, int, int>();
-            int firstInt = 1;
-            int secondInt = 2;
-            int thirdInt = 3;
-            int fourthInt = 4;
-
+            this.CreateFourInts();
             signal.AddListener(FourArgCallback);
             signal.AddListener(FourArgCallback);
 
-            signal.Dispatch(firstInt, secondInt, thirdInt, fourthInt);
-            int expected = firstInt + secondInt + thirdInt + fourthInt;
+            signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
 
+            int expected = this.GetFourIntExpected();
+            Assert.AreEqual(expected, this.testValue);
+        }
+
+        [Test]
+        public void AddOnce_SignalWithFourTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+        {
+            Signal<int, int, int, int> signal = new Signal<int, int, int, int>();
+            this.CreateFourInts();
+            signal.AddOnce(FourArgCallback);
+            signal.AddOnce(FourArgCallback);
+
+            signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+
+            int expected = this.GetFourIntExpected();
             Assert.AreEqual(expected, this.testValue);
 
+        }
+
+        private int GetFourIntExpected()
+        {
+            return this.GetThreeIntExpected() + testIntFour;
+        }
+
+        private void CreateFourInts()
+        {
+            this.CreateThreeInts();
+            this.testIntFour = 4;
+        }
+
+        private void CreateThreeInts()
+        {
+            this.CreateTwoInts();
+            this.testIntThree = 3;
+        }
+
+        private void CreateTwoInts()
+        {
+            this.CreateOneInt();
+            this.testIntTwo = 2;
+        }
+
+        private void CreateOneInt()
+        {
+            this.testInt = 1;
         }
 
         private void FourArgCallback(int arg1, int arg2, int arg3, int arg4)
@@ -250,7 +381,22 @@ namespace strange.unittests
 
             signal.RemoveListener(OneArgSignalCallback);
             signal.Dispatch(testInt);
-            Assert.AreEqual(testInt, testValue); //should not have changed
+            Assert.AreEqual(testInt, testValue);
+        }
+
+        [Test]
+        public void RemoveListener_NoType_ExpectsListenerRemoved()
+        {
+            Signal signal = new Signal();
+
+            signal.AddListener(NoArgSignalCallback);
+
+            signal.Dispatch();
+            Assert.AreEqual(1, testValue);
+
+            signal.RemoveListener(NoArgSignalCallback);
+            signal.Dispatch();
+            Assert.AreEqual(1, testValue);
         }
 
         //callbacks
@@ -288,5 +434,5 @@ namespace strange.unittests
             testValue *= three;
             testValue -= four;
         }
-	}
+    }
 }

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
@@ -31,6 +31,7 @@ namespace strange.extensions.signal.impl
 {
 	public class BaseSignal : IBaseSignal
 	{
+        
 		/// The delegate for repeating listeners
 		public event Action<IBaseSignal, object[]> BaseListener = delegate { };
 
@@ -66,11 +67,13 @@ namespace strange.extensions.signal.impl
 				if (callback.Equals(action)) //If this callback exists already, ignore this addlistener
 					return;
 			}
+
 			OnceBaseListener += callback;
 		}
 
 		public void RemoveListener(Action<IBaseSignal, object[]> callback) { BaseListener -= callback; }
 
+	   
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
@@ -65,169 +65,219 @@
  */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace strange.extensions.signal.impl
 {
-	/// Base concrete form for a Signal with no parameters
-	public class Signal : BaseSignal
-	{
-		public event Action Listener = delegate { };
-		public event Action OnceListener = delegate { };
+    /// Base concrete form for a Signal with no parameters
+    public class Signal : BaseSignal
+    {
+        public event Action Listener = delegate { };
+        public event Action OnceListener = delegate { };
 
-	    public void AddListener(Action callback)
-	    {
-            if (!Listener.GetInvocationList().Contains(callback))
-            {
-                Listener += callback;
-            }
-	    }
-
-	    public void AddOnce(Action callback) { OnceListener += callback; }
-		public void RemoveListener(Action callback) { Listener -= callback; }
-		public override List<Type> GetTypes()
-		{
-			return new List<Type>();
-		}
-		public void Dispatch()
-		{
-			Listener();
-			OnceListener();
-			OnceListener = delegate { };
-			base.Dispatch(null);
-		}
-	}
-
-	/// Base concrete form for a Signal with one parameter
-	public class Signal<T> : BaseSignal
-	{
-		public event Action<T> Listener = delegate { };
-		public event Action<T> OnceListener = delegate { };	    
-
-	    public void AddListener(Action<T> callback)
-	    {
-	        if (!Listener.GetInvocationList().Contains(callback))
-	        {
-	            Listener += callback;
-	        }
-	    }
-		public void AddOnce(Action<T> callback) { OnceListener += callback; }
-		public void RemoveListener(Action<T> callback) { Listener -= callback; }
-		public override  List<Type> GetTypes() 
-		{ 
-			List<Type> retv = new List<Type>();
-			retv.Add(typeof(T));
-			return retv;
-		}
-		public void Dispatch(T type1)
-		{
-			Listener(type1);
-			OnceListener(type1);
-			OnceListener = delegate { };
-			object[] outv = { type1 };
-			base.Dispatch(outv);
-		}
-	}
-
-	/// Base concrete form for a Signal with two parameters
-	public class Signal<T, U> : BaseSignal
-	{
-		public event Action<T, U> Listener = delegate { };
-		public event Action<T, U> OnceListener = delegate { };
-
-	    public void AddListener(Action<T, U> callback)
-	    {
-            if (!Listener.GetInvocationList().Contains(callback))
-            {
-                Listener += callback;
-            }
+        public void AddListener(Action callback)
+        {
+            Listener = this.AddUnique(Listener, callback);
         }
-		public void AddOnce(Action<T, U> callback) { OnceListener += callback; }
-		public void RemoveListener(Action<T, U> callback) { Listener -= callback; }
-		public override List<Type> GetTypes()
-		{
-			List<Type> retv = new List<Type>();
-			retv.Add(typeof(T));
-			retv.Add(typeof(U));
-			return retv;
-		}
-		public void Dispatch(T type1, U type2)
-		{
-			Listener(type1, type2);
-			OnceListener(type1, type2);
-			OnceListener = delegate { };
-			object[] outv = { type1, type2 };
-			base.Dispatch(outv);
-		}
-	}
 
-	/// Base concrete form for a Signal with three parameters
-	public class Signal<T, U, V> : BaseSignal
-	{
-		public event Action<T, U, V> Listener = delegate { };
-		public event Action<T, U, V> OnceListener = delegate { };
+        public void AddOnce(Action callback)
+        {
+            OnceListener = this.AddUnique(Listener, callback);
+        }
+        public void RemoveListener(Action callback) { Listener -= callback; }
+        public override List<Type> GetTypes()
+        {
+            return new List<Type>();
+        }
+        public void Dispatch()
+        {
+            Listener();
+            OnceListener();
+            OnceListener = delegate { };
+            base.Dispatch(null);
+        }
 
-	    public void AddListener(Action<T, U, V> callback)
-	    {
-            if (!Listener.GetInvocationList().Contains(callback))
+        private Action AddUnique(Action listeners, Action callback)
+        {
+            if (!listeners.GetInvocationList().Contains(callback))
             {
-                Listener += callback;
+                listeners += callback;
             }
-	    }
-		public void AddOnce(Action<T, U, V> callback) { OnceListener += callback; }
-		public void RemoveListener(Action<T, U, V> callback) { Listener -= callback; }
-		public override List<Type> GetTypes()
-		{
-			List<Type> retv = new List<Type>();
-			retv.Add(typeof(T));
-			retv.Add(typeof(U));
-			retv.Add(typeof(V));
-			return retv;
-		}
-		public void Dispatch(T type1, U type2, V type3)
-		{
-			Listener(type1, type2, type3);
-			OnceListener(type1, type2, type3);
-			OnceListener = delegate { };
-			object[] outv = { type1, type2, type3 };
-			base.Dispatch(outv);
-		}
-	}
+            return listeners;
+        }
+    }
 
-	/// Base concrete form for a Signal with four parameters
-	public class Signal<T, U, V, W> : BaseSignal
-	{
-		public event Action<T, U, V, W> Listener = delegate { };
-		public event Action<T, U, V, W> OnceListener = delegate { };
+    /// Base concrete form for a Signal with one parameter
+    public class Signal<T> : BaseSignal
+    {
+        public event Action<T> Listener = delegate { };
+        public event Action<T> OnceListener = delegate { };
 
-	    public void AddListener(Action<T, U, V, W> callback)
-	    {
-            if (!Listener.GetInvocationList().Contains(callback))
+        public void AddListener(Action<T> callback)
+        {
+            Listener = this.AddUnique(Listener, callback);
+        }
+
+        public void AddOnce(Action<T> callback)
+        {
+            OnceListener = this.AddUnique(Listener, callback);
+        }
+
+        public void RemoveListener(Action<T> callback) { Listener -= callback; }
+        public override List<Type> GetTypes()
+        {
+            List<Type> retv = new List<Type>();
+            retv.Add(typeof(T));
+            return retv;
+        }
+        public void Dispatch(T type1)
+        {
+            Listener(type1);
+            OnceListener(type1);
+            OnceListener = delegate { };
+            object[] outv = { type1 };
+            base.Dispatch(outv);
+        }
+
+        private Action<T> AddUnique(Action<T> listeners, Action<T> callback)
+        {
+            if (!listeners.GetInvocationList().Contains(callback))
             {
-                Listener += callback;
+                listeners += callback;
             }
-	    }
-		public void AddOnce(Action<T, U, V, W> callback) { OnceListener += callback; }
-		public void RemoveListener(Action<T, U, V, W> callback) { Listener -= callback; }
-		public override List<Type> GetTypes()
-		{
-			List<Type> retv = new List<Type>();
-			retv.Add(typeof(T));
-			retv.Add(typeof(U));
-			retv.Add(typeof(V));
-			retv.Add(typeof(W));
-			return retv;
-		}
-		public void Dispatch(T type1, U type2, V type3, W type4)
-		{
-			Listener(type1, type2, type3, type4);
-			OnceListener(type1, type2, type3, type4);
-			OnceListener = delegate { };
-			object[] outv = { type1, type2, type3, type4 };
-			base.Dispatch(outv);
-		}
-	}
+            return listeners;
+        }
+    }
+
+    /// Base concrete form for a Signal with two parameters
+    public class Signal<T, U> : BaseSignal
+    {
+        public event Action<T, U> Listener = delegate { };
+        public event Action<T, U> OnceListener = delegate { };
+
+        public void AddListener(Action<T, U> callback)
+        {
+            Listener = this.AddUnique(Listener, callback);
+        }
+
+        public void AddOnce(Action<T, U> callback)
+        {
+            OnceListener = this.AddUnique(Listener, callback);
+        }
+
+        public void RemoveListener(Action<T, U> callback) { Listener -= callback; }
+        public override List<Type> GetTypes()
+        {
+            List<Type> retv = new List<Type>();
+            retv.Add(typeof(T));
+            retv.Add(typeof(U));
+            return retv;
+        }
+        public void Dispatch(T type1, U type2)
+        {
+            Listener(type1, type2);
+            OnceListener(type1, type2);
+            OnceListener = delegate { };
+            object[] outv = { type1, type2 };
+            base.Dispatch(outv);
+        }
+        private Action<T, U> AddUnique(Action<T, U> listeners, Action<T, U> callback)
+        {
+            if (!listeners.GetInvocationList().Contains(callback))
+            {
+                listeners += callback;
+            }
+            return listeners;
+        }
+    }
+
+    /// Base concrete form for a Signal with three parameters
+    public class Signal<T, U, V> : BaseSignal
+    {
+        public event Action<T, U, V> Listener = delegate { };
+        public event Action<T, U, V> OnceListener = delegate { };
+
+        public void AddListener(Action<T, U, V> callback)
+        {
+            Listener = this.AddUnique(Listener, callback);
+        }
+
+        public void AddOnce(Action<T, U, V> callback)
+        {
+            OnceListener = this.AddUnique(OnceListener, callback);
+        }
+
+        public void RemoveListener(Action<T, U, V> callback) { Listener -= callback; }
+        public override List<Type> GetTypes()
+        {
+            List<Type> retv = new List<Type>();
+            retv.Add(typeof(T));
+            retv.Add(typeof(U));
+            retv.Add(typeof(V));
+            return retv;
+        }
+        public void Dispatch(T type1, U type2, V type3)
+        {
+            Listener(type1, type2, type3);
+            OnceListener(type1, type2, type3);
+            OnceListener = delegate { };
+            object[] outv = { type1, type2, type3 };
+            base.Dispatch(outv);
+        }
+        private Action<T, U, V> AddUnique(Action<T, U, V> listeners, Action<T, U, V> callback)
+        {
+            if (!listeners.GetInvocationList().Contains(callback))
+            {
+                listeners += callback;
+            }
+            return listeners;
+        }
+    }
+
+    /// Base concrete form for a Signal with four parameters
+    public class Signal<T, U, V, W> : BaseSignal
+    {
+        public event Action<T, U, V, W> Listener = delegate { };
+        public event Action<T, U, V, W> OnceListener = delegate { };
+
+        public void AddListener(Action<T, U, V, W> callback)
+        {
+            Listener = this.AddUnique(Listener, callback);
+        }
+
+        public void AddOnce(Action<T, U, V, W> callback)
+        {
+            OnceListener = this.AddUnique(OnceListener, callback);
+        }
+
+        public void RemoveListener(Action<T, U, V, W> callback) { Listener -= callback; }
+        public override List<Type> GetTypes()
+        {
+            List<Type> retv = new List<Type>();
+            retv.Add(typeof(T));
+            retv.Add(typeof(U));
+            retv.Add(typeof(V));
+            retv.Add(typeof(W));
+            return retv;
+        }
+        public void Dispatch(T type1, U type2, V type3, W type4)
+        {
+            Listener(type1, type2, type3, type4);
+            OnceListener(type1, type2, type3, type4);
+            OnceListener = delegate { };
+            object[] outv = { type1, type2, type3, type4 };
+            base.Dispatch(outv);
+        }
+
+        private Action<T, U, V, W> AddUnique(Action<T, U, V, W> listeners, Action<T, U, V, W> callback)
+        {
+            if (!listeners.GetInvocationList().Contains(callback))
+            {
+                listeners += callback;
+            }
+            return listeners;
+        }
+    }
 
 }


### PR DESCRIPTION
In a nutshell, we noticed that BaseSignal does something akin to what we're doing with this commit by preventing AddListener from adding the same delegate multiple times.  Here we've added the corresponding tests and code that provide that.

On that note, we did have some suggestion for naming AddOnce.  What if it were named to something like CallDelegateOnce, or something similar?  AddOnce only reveals its intent after reading the source, and is easy to mistake for something that "Only adds a delegate listener once".  

We also had a question about Signal inheriting from BaseSignal.  Signal re-implements every aspect of BaseSignal, only in the Dispatch method is there any re-use of code.  Related to this is that this inheritance violates the Liskov substitution principle.  One cannot use a Signal and a BaseSignal interchangeably.  Even if this is on purpose, maybe there's some way to reduce the quadruple duplication?  If we come up with something, we'll be sure to let you know.
