### PR TITLE
Added code to allow for automatic un-listening to signals in mediators

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignalsMediator.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignalsMediator.cs
@@ -1,0 +1,157 @@
+﻿using NUnit.Framework;
+using strange.extensions.context.api;
+using strange.extensions.injector.api;
+using strange.extensions.injector.impl;
+using strange.extensions.mediation.impl;
+using strange.extensions.signal.impl;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace strange.unittests
+{
+    [TestFixture()]
+	public class TestSignalsMediator : BaseUnitTest
+    {
+        class MockView : View
+        {
+            public Signal noParmSignal = new Signal();
+            public Signal<int> oneParamSignal = new Signal<int>();
+            public Signal<int, string> twoParamSignal = new Signal<int, string>();
+            public Signal<int, string, bool> threeParamSignal = new Signal<int, string, bool>();
+            public Signal<int, string, bool, float> fourParamSignal = new Signal<int, string, bool, float>();
+        }
+
+        class MockMediator : SignalsMediator
+        {
+            [Inject]
+            public MockView View { get; set; }
+
+            public bool noParamCalled = false;
+
+            public bool oneParamCalled = false;
+            public int oneParamValue = -1;
+
+            public bool twoParamCalled = false;
+            public int twoParamValueA = -1;
+            public string twoParamValueB = null;
+
+            public bool threeParamCalled = false;
+            public int threeParamValueA = -1;
+            public string threeParamValueB = null;
+            public bool threeParamValueC = false;
+
+            public bool fourParamCalled = false;
+            public int fourParamValueA = -1;
+            public string fourParamValueB = null;
+            public bool fourParamValueC = false;
+            public float fourParamValueD = -1.1f;
+
+            public override void OnRegister()
+            {
+                RegisterListener(View.noParmSignal, () => noParamCalled = true);
+
+                RegisterListener(View.oneParamSignal, a =>
+                {
+                    oneParamCalled = true;
+                    oneParamValue = a;
+                });
+
+                RegisterListener(View.twoParamSignal, (a, b) =>
+                {
+                    twoParamCalled = true;
+                    twoParamValueA = a;
+                    twoParamValueB = b;
+                });
+
+                RegisterListener(View.threeParamSignal, (a, b, c) =>
+                {
+                    threeParamCalled = true;
+                    threeParamValueA = a;
+                    threeParamValueB = b;
+                    threeParamValueC = c;
+                });
+
+                RegisterListener(View.fourParamSignal, (a, b, c, d) =>
+                {
+                    fourParamCalled = true;
+                    fourParamValueA = a;
+                    fourParamValueB = b;
+                    fourParamValueC = c;
+                    fourParamValueD = d;
+                });
+            }
+        }
+
+        private InjectionBinder injector;
+        private MockMediator mediator;
+        private MockView view;
+
+        [SetUp]
+        public void Init()
+        {
+            view = new MockView();
+            injector = new InjectionBinder();
+            injector.Bind<GameObject>().ToName(ContextKeys.CONTEXT_VIEW).ToValue(new GameObject());
+            injector.Bind<MockView>().ToValue(view);
+            injector.Bind<MockMediator>().ToSingleton();
+            injector.Bind<IInjectionBinder>().ToValue(injector);
+            mediator = injector.GetInstance<MockMediator>();
+            mediator.OnRegister();
+        }
+
+        [Test]
+        public void NothingCalled()
+        {
+            Assert.AreEqual(false, mediator.noParamCalled);
+            Assert.AreEqual(false, mediator.oneParamCalled);
+            Assert.AreEqual(false, mediator.twoParamCalled);
+            Assert.AreEqual(false, mediator.threeParamCalled);
+            Assert.AreEqual(false, mediator.fourParamCalled);
+        }
+
+        [Test]
+        public void CallbacksGetCalled()
+        {
+            view.noParmSignal.Dispatch();
+            Assert.AreEqual(true, mediator.noParamCalled);
+            view.oneParamSignal.Dispatch(12345);
+            Assert.AreEqual(true, mediator.oneParamCalled);
+            Assert.AreEqual(12345, mediator.oneParamValue);
+            view.twoParamSignal.Dispatch(12345,"hello");
+            Assert.AreEqual(true, mediator.twoParamCalled);
+            Assert.AreEqual(12345, mediator.twoParamValueA);
+            Assert.AreEqual("hello", mediator.twoParamValueB);
+            view.threeParamSignal.Dispatch(12345, "hello", true);
+            Assert.AreEqual(true, mediator.threeParamCalled);
+            Assert.AreEqual(12345, mediator.threeParamValueA);
+            Assert.AreEqual("hello", mediator.threeParamValueB);
+            Assert.AreEqual(true, mediator.threeParamValueC);
+            view.fourParamSignal.Dispatch(12345, "hello", true, 12.345f);
+            Assert.AreEqual(true, mediator.fourParamCalled);
+            Assert.AreEqual(12345, mediator.fourParamValueA);
+            Assert.AreEqual("hello", mediator.fourParamValueB);
+            Assert.AreEqual(true, mediator.fourParamValueC);
+            Assert.AreEqual(12.345f, mediator.fourParamValueD);
+        }
+
+        [Test]
+        public void CallbacksDoNotGetCalledAfterRemoval()
+        {
+            mediator.OnPreRemove();
+            view.noParmSignal.Dispatch();
+            Assert.AreEqual(false, mediator.noParamCalled);
+            view.oneParamSignal.Dispatch(12345);
+            Assert.AreEqual(false, mediator.oneParamCalled);
+            view.twoParamSignal.Dispatch(12345, "hello");
+            Assert.AreEqual(false, mediator.twoParamCalled);
+            view.threeParamSignal.Dispatch(12345, "hello", true);
+            Assert.AreEqual(false, mediator.threeParamCalled);
+            view.fourParamSignal.Dispatch(12345, "hello", true, 12.345f);
+            Assert.AreEqual(false, mediator.fourParamCalled);
+        }
+    }
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/mediation/api/IMediator.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/api/IMediator.cs
@@ -41,6 +41,10 @@ namespace strange.extensions.mediation.api
 		/// Override to perform the actions you might normally perform in a constructor.
 		void OnRegister();
 
+        /// This method fires just before OnRemove, mediator base classes can use it do do any cleaning up without worrying that
+        /// implementing classes will override it and things wont get cleaned up
+        void OnPreRemove();
+
 		/// This method fires just before a GameObject will be destroyed.
 		/// Override to clean up any listeners, or anything else that might keep the View/Mediator pair from being garbage collected.
 		void OnRemove();

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -157,6 +157,7 @@ namespace strange.extensions.mediation.impl
 					IMediator mediator = mono.GetComponent(mediatorType) as IMediator;
 					if (mediator != null)
 					{
+                        mediator.OnPreRemove();
 						mediator.OnRemove();
 					}
 				}

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/Mediator.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/Mediator.cs
@@ -54,6 +54,15 @@ namespace strange.extensions.mediation.impl
 		{
 		}
 
+        /**
+		 * Fires just before OnRemove
+		 *
+		 * Override and place your cleanup code here
+		 */
+        virtual public void OnPreRemove()
+        {
+        }
+
 		/**
 		 * Fires on removal of view.
 		 *
@@ -61,7 +70,7 @@ namespace strange.extensions.mediation.impl
 		 */
 		virtual public void OnRemove()
 		{
-		}
+		}        
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/signal/api/IBaseSignal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/api/IBaseSignal.cs
@@ -59,13 +59,13 @@ namespace strange.extensions.signal.api
 		/// Attach a callback to this Signal
 		/// The callback parameters must match the Types and order which were
 		/// originally assigned to the Signal on its creation
-		void AddListener(Action<IBaseSignal, object[]> callback);
+        void AddListener(Action<IBaseSignal, object[]> callback);
 
 		/// Attach a callback to this Signal for the duration of exactly one Dispatch
 		/// The callback parameters must match the Types and order which were
 		/// originally assigned to the Signal on its creation, and the callback
 		/// will be removed immediately after the Signal dispatches
-		void AddOnce (Action<IBaseSignal, object[]> callback);
+        void AddOnce(Action<IBaseSignal, object[]> callback);
 
 		/// Remove a callback from this Signal
 		void RemoveListener(Action<IBaseSignal, object[]> callback);

--- a/StrangeIoC/scripts/strange/extensions/signal/api/ISignalBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/api/ISignalBinding.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace strange.extensions.signal.api
+{
+    public interface ISignalBinding
+    {
+        void RemoveBinding();
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/signal/api/ISignalBinding.cs.meta
+++ b/StrangeIoC/scripts/strange/extensions/signal/api/ISignalBinding.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c619a55229b514449dc5e444463279b
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
@@ -64,132 +64,196 @@
  * @see strange.extensions.signal.impl.BasrSignal
  */
 
+using strange.extensions.signal.api;
 using System;
 using System.Collections.Generic;
 
 namespace strange.extensions.signal.impl
 {
-	/// Base concrete form for a Signal with no parameters
-	public class Signal : BaseSignal
-	{
-		public event Action Listener = delegate { };
-		public event Action OnceListener = delegate { };
-		public void AddListener(Action callback) { Listener += callback; }
-		public void AddOnce(Action callback) { OnceListener += callback; }
-		public void RemoveListener(Action callback) { Listener -= callback; }
-		public override List<Type> GetTypes()
-		{
-			return new List<Type>();
-		}
-		public void Dispatch()
-		{
-			Listener();
-			OnceListener();
-			OnceListener = delegate { };
-			base.Dispatch(null);
-		}
-	}
+    /// Base concrete form for a Signal with no parameters
+    public class Signal : BaseSignal
+    {
+        public event Action Listener = delegate { };
+        public event Action OnceListener = delegate { };
 
-	/// Base concrete form for a Signal with one parameter
-	public class Signal<T> : BaseSignal
-	{
-		public event Action<T> Listener = delegate { };
-		public event Action<T> OnceListener = delegate { };
-		public void AddListener(Action<T> callback) { Listener += callback; }
-		public void AddOnce(Action<T> callback) { OnceListener += callback; }
-		public void RemoveListener(Action<T> callback) { Listener -= callback; }
-		public override  List<Type> GetTypes() 
-		{ 
-			List<Type> retv = new List<Type>();
-			retv.Add(typeof(T));
-			return retv;
-		}
-		public void Dispatch(T type1)
-		{
-			Listener(type1);
-			OnceListener(type1);
-			OnceListener = delegate { };
-			object[] outv = { type1 };
-			base.Dispatch(outv);
-		}
-	}
+        public SignalBinding AddListener(Action callback)
+        {
+            Listener += callback;
+            return new SignalBinding(this, callback);
+        }
 
-	/// Base concrete form for a Signal with two parameters
-	public class Signal<T, U> : BaseSignal
-	{
-		public event Action<T, U> Listener = delegate { };
-		public event Action<T, U> OnceListener = delegate { };
-		public void AddListener(Action<T, U> callback) { Listener += callback; }
-		public void AddOnce(Action<T, U> callback) { OnceListener += callback; }
-		public void RemoveListener(Action<T, U> callback) { Listener -= callback; }
-		public override List<Type> GetTypes()
-		{
-			List<Type> retv = new List<Type>();
-			retv.Add(typeof(T));
-			retv.Add(typeof(U));
-			return retv;
-		}
-		public void Dispatch(T type1, U type2)
-		{
-			Listener(type1, type2);
-			OnceListener(type1, type2);
-			OnceListener = delegate { };
-			object[] outv = { type1, type2 };
-			base.Dispatch(outv);
-		}
-	}
+        public SignalBinding AddOnce(Action callback) 
+        {
+            OnceListener += callback;
+            return new SignalBinding(this, callback);
+           // return callback; 
+        }
 
-	/// Base concrete form for a Signal with three parameters
-	public class Signal<T, U, V> : BaseSignal
-	{
-		public event Action<T, U, V> Listener = delegate { };
-		public event Action<T, U, V> OnceListener = delegate { };
-		public void AddListener(Action<T, U, V> callback) { Listener += callback; }
-		public void AddOnce(Action<T, U, V> callback) { OnceListener += callback; }
-		public void RemoveListener(Action<T, U, V> callback) { Listener -= callback; }
-		public override List<Type> GetTypes()
-		{
-			List<Type> retv = new List<Type>();
-			retv.Add(typeof(T));
-			retv.Add(typeof(U));
-			retv.Add(typeof(V));
-			return retv;
-		}
-		public void Dispatch(T type1, U type2, V type3)
-		{
-			Listener(type1, type2, type3);
-			OnceListener(type1, type2, type3);
-			OnceListener = delegate { };
-			object[] outv = { type1, type2, type3 };
-			base.Dispatch(outv);
-		}
-	}
+        public void RemoveListener(Action callback) { Listener -= callback; }
 
-	/// Base concrete form for a Signal with four parameters
-	public class Signal<T, U, V, W> : BaseSignal
-	{
-		public event Action<T, U, V, W> Listener = delegate { };
-		public event Action<T, U, V, W> OnceListener = delegate { };
-		public void AddListener(Action<T, U, V, W> callback) { Listener += callback; }
-		public void AddOnce(Action<T, U, V, W> callback) { OnceListener += callback; }
-		public void RemoveListener(Action<T, U, V, W> callback) { Listener -= callback; }
-		public override List<Type> GetTypes()
-		{
-			List<Type> retv = new List<Type>();
-			retv.Add(typeof(T));
-			retv.Add(typeof(U));
-			retv.Add(typeof(V));
-			retv.Add(typeof(W));
-			return retv;
-		}
-		public void Dispatch(T type1, U type2, V type3, W type4)
-		{
-			Listener(type1, type2, type3, type4);
-			OnceListener(type1, type2, type3, type4);
-			OnceListener = delegate { };
-			object[] outv = { type1, type2, type3, type4 };
-			base.Dispatch(outv);
-		}
-	}
+        public override List<Type> GetTypes()
+        {
+            return new List<Type>();
+        }
+
+        public void Dispatch()
+        {
+            Listener();
+            OnceListener();
+            OnceListener = delegate { };
+            base.Dispatch(null);
+        }
+    }
+
+    /// Base concrete form for a Signal with one parameter
+    public class Signal<T> : BaseSignal
+    {
+        public event Action<T> Listener = delegate { };
+        public event Action<T> OnceListener = delegate { };
+
+        public SignalBinding<T> AddListener(Action<T> callback)
+        {
+            Listener += callback;
+            return new SignalBinding<T>(this, callback);
+        }
+
+        public SignalBinding<T> AddOnce(Action<T> callback) 
+        {
+            OnceListener += callback;
+            return new SignalBinding<T>(this, callback);
+            //return callback; 
+        }
+
+        public void RemoveListener(Action<T> callback) { Listener -= callback; }
+
+        public override List<Type> GetTypes()
+        {
+            List<Type> retv = new List<Type>();
+            retv.Add(typeof(T));
+            return retv;
+        }
+        public void Dispatch(T type1)
+        {
+            Listener(type1);
+            OnceListener(type1);
+            OnceListener = delegate { };
+            object[] outv = { type1 };
+            base.Dispatch(outv);
+        }
+    }
+
+    /// Base concrete form for a Signal with two parameters
+    public class Signal<T, U> : BaseSignal
+    {
+        public event Action<T, U> Listener = delegate { };
+        public event Action<T, U> OnceListener = delegate { };
+
+        public SignalBinding<T, U> AddListener(Action<T, U> callback)
+        {
+            Listener += callback;
+            return new SignalBinding<T,U>(this, callback);
+        }
+
+        public SignalBinding<T, U> AddOnce(Action<T, U> callback)
+        {
+            OnceListener += callback;
+            return new SignalBinding<T, U>(this, callback);
+        }
+
+        public void RemoveListener(Action<T, U> callback) { Listener -= callback; }
+
+        public override List<Type> GetTypes()
+        {
+            List<Type> retv = new List<Type>();
+            retv.Add(typeof(T));
+            retv.Add(typeof(U));
+            return retv;
+        }
+        public void Dispatch(T type1, U type2)
+        {
+            Listener(type1, type2);
+            OnceListener(type1, type2);
+            OnceListener = delegate { };
+            object[] outv = { type1, type2 };
+            base.Dispatch(outv);
+        }
+    }
+
+    /// Base concrete form for a Signal with three parameters
+    public class Signal<T, U, V> : BaseSignal
+    {
+        public event Action<T, U, V> Listener = delegate { };
+        public event Action<T, U, V> OnceListener = delegate { };
+
+        public SignalBinding<T, U, V> AddListener(Action<T, U, V> callback)
+        {
+            Listener += callback;
+            return new SignalBinding<T, U, V>(this, callback);
+        }
+
+        public SignalBinding<T, U, V> AddOnce(Action<T, U, V> callback) 
+        {
+            OnceListener += callback;
+            return new SignalBinding<T, U, V>(this, callback);
+        }
+
+        public void RemoveListener(Action<T, U, V> callback) { Listener -= callback; }
+
+        public override List<Type> GetTypes()
+        {
+            List<Type> retv = new List<Type>();
+            retv.Add(typeof(T));
+            retv.Add(typeof(U));
+            retv.Add(typeof(V));
+            return retv;
+        }
+        public void Dispatch(T type1, U type2, V type3)
+        {
+            Listener(type1, type2, type3);
+            OnceListener(type1, type2, type3);
+            OnceListener = delegate { };
+            object[] outv = { type1, type2, type3 };
+            base.Dispatch(outv);
+        }
+    }
+
+    /// Base concrete form for a Signal with four parameters
+    public class Signal<T, U, V, W> : BaseSignal
+    {
+        public event Action<T, U, V, W> Listener = delegate { };
+        public event Action<T, U, V, W> OnceListener = delegate { };
+       
+        public SignalBinding<T, U, V, W> AddListener(Action<T, U, V, W> callback)
+        {
+            Listener += callback;
+            return new SignalBinding<T, U, V, W>(this, callback);
+        }
+
+        public SignalBinding<T, U, V, W> AddOnce(Action<T, U, V, W> callback) 
+        {
+            OnceListener += callback;
+            return new SignalBinding<T, U, V, W>(this, callback);
+        }
+
+        public void RemoveListener(Action<T, U, V, W> callback) { Listener -= callback; }
+
+        public override List<Type> GetTypes()
+        {
+            List<Type> retv = new List<Type>();
+            retv.Add(typeof(T));
+            retv.Add(typeof(U));
+            retv.Add(typeof(V));
+            retv.Add(typeof(W));
+            return retv;
+        }
+        public void Dispatch(T type1, U type2, V type3, W type4)
+        {
+            Listener(type1, type2, type3, type4);
+            OnceListener(type1, type2, type3, type4);
+            OnceListener = delegate { };
+            object[] outv = { type1, type2, type3, type4 };
+            base.Dispatch(outv);
+        }
+    }
 
 }

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/SignalBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/SignalBinding.cs
@@ -1,0 +1,94 @@
+﻿using strange.extensions.signal.api;
+using strange.extensions.signal.impl;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace strange.extensions.signal.impl
+{
+    public class SignalBinding : ISignalBinding
+    {
+        public Signal Signal { get; private set; }
+        public Action Callback { get; private set; }
+
+        public SignalBinding(Signal signal, Action callback)
+        {
+            Signal = signal;
+            Callback = callback;
+        }
+
+        public void RemoveBinding()
+        {
+            Signal.RemoveListener(Callback);
+        }
+    }
+
+    public class SignalBinding<T> : ISignalBinding
+    {
+        public Signal<T> Signal { get; private set; }
+        public Action<T> Callback { get; private set; }
+
+        public SignalBinding(Signal<T> signal, Action<T> callback)
+        {
+            Signal = signal;
+            Callback = callback;
+        }
+
+        public void RemoveBinding()
+        {
+            Signal.RemoveListener(Callback);
+        }
+    }
+
+    public class SignalBinding<T,U> : ISignalBinding
+    {
+        public Signal<T,U> Signal { get; private set; }
+        public Action<T,U> Callback { get; private set; }
+
+        public SignalBinding(Signal<T,U> signal, Action<T,U> callback)
+        {
+            Signal = signal;
+            Callback = callback;
+        }
+
+        public void RemoveBinding()
+        {
+            Signal.RemoveListener(Callback);
+        }
+    }
+
+    public class SignalBinding<T, U, V> : ISignalBinding
+    {
+        public Signal<T, U, V> Signal { get; private set; }
+        public Action<T, U, V> Callback { get; private set; }
+
+        public SignalBinding(Signal<T, U, V> signal, Action<T, U, V> callback)
+        {
+            Signal = signal;
+            Callback = callback;
+        }
+
+        public void RemoveBinding()
+        {
+            Signal.RemoveListener(Callback);
+        }
+    }
+
+    public class SignalBinding<T, U, V, W> : ISignalBinding
+    {
+        public Signal<T, U, V, W> Signal { get; private set; }
+        public Action<T, U, V, W> Callback { get; private set; }
+
+        public SignalBinding(Signal<T, U, V, W> signal, Action<T, U, V, W> callback)
+        {
+            Signal = signal;
+            Callback = callback;
+        }
+
+        public void RemoveBinding()
+        {
+            Signal.RemoveListener(Callback);
+        }
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/SignalBinding.cs.meta
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/SignalBinding.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3673e94f062ad504fb6a408a2aac360d
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/SignalsMediator.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/SignalsMediator.cs
@@ -1,0 +1,58 @@
+﻿using strange.extensions.mediation.impl;
+using strange.extensions.signal.api;
+using strange.extensions.signal.impl;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace strange.extensions.signal.impl
+{
+    public class SignalsMediator : Mediator
+    {
+        // Using lazy instantiation so not to use unneccessary memory
+        private List<ISignalBinding> _signalBindings;
+        protected List<ISignalBinding> SignalBindings 
+        {
+            get
+            {
+                if (_signalBindings == null) _signalBindings = new List<ISignalBinding>();
+                return _signalBindings;
+            }
+        }
+
+        override public void OnPreRemove()
+        {
+            // Perhaps no signals were added, so no need to call the getter which would then instantiate a list
+            if (_signalBindings==null) return;
+
+            // Remove each binding
+            SignalBindings.ForEach(r => r.RemoveBinding());
+        }
+
+        protected void RegisterListener(Signal signal, Action callback)
+        {
+            SignalBindings.Add(signal.AddListener(callback));
+        }
+
+        protected void RegisterListener<T>(Signal<T> signal, Action<T> callback)
+        {
+            SignalBindings.Add(signal.AddListener(callback));
+        }
+
+        protected void RegisterListener<T, U>(Signal<T, U> signal, Action<T, U> callback)
+        {
+            SignalBindings.Add(signal.AddListener(callback));
+        }
+
+        protected void RegisterListener<T, U, V>(Signal<T, U, V> signal, Action<T, U, V> callback)
+        {
+            SignalBindings.Add(signal.AddListener(callback));
+        }
+
+        protected void RegisterListener<T, U, V, W>(Signal<T, U, V, W> signal, Action<T, U, V, W> callback)
+        {
+            SignalBindings.Add(signal.AddListener(callback));
+        }
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/SignalsMediator.cs.meta
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/SignalsMediator.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d5767654cda37640b6103a227954340
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 


### PR DESCRIPTION
As per this post: https://groups.google.com/forum/#!topic/strangeioc/xXCq-2zm4U4

You can now simply extend "[SignalsMediator](https://github.com/strangeioc/strangeioc/pull/105/files#diff-1fe7e9b258fee3db48271309104f7c3fR11)" then use any "[RegisterListener](https://github.com/strangeioc/strangeioc/pull/105/files#diff-db9be480f29958af07133208d3ce9a41R56)" method to have your signals automatically unlistened when the mediator is destroyed. 

To accomplish this I have added a "[SignalBinding](https://github.com/strangeioc/strangeioc/pull/105/files#diff-9b592520668659645912d22fa36b064bR10)" class (well 4 of them actually) that maintains a reference between the signal and the listener. That way the binding can be stored in a single list in [SignalsMediator](https://github.com/strangeioc/strangeioc/pull/105/files#diff-1fe7e9b258fee3db48271309104f7c3fR11) (they all implement ISignalBinding) and thus can be [iterated over when the mediator is destroyed](https://github.com/strangeioc/strangeioc/pull/105/files#diff-1fe7e9b258fee3db48271309104f7c3fR30). 

For added sugar I have added a "[OnPreRemove](https://github.com/strangeioc/strangeioc/pull/105/files#diff-6d1de0eb985175b3a2081c13087a03f8R46)" method to IMediator and gets called immediately before OnRemove, this allows SignalsMediator (and any other base classes) to do any cleaning up and not worry that OnRemove may be overridden and not be calling the super OnRemove.

I have included [some tests](https://github.com/strangeioc/strangeioc/pull/105/files#diff-db9be480f29958af07133208d3ce9a41R16) although I havent actually run them from within the source directory as I had issues with how to structure the git clone (see https://groups.google.com/forum/#!topic/strangeioc/pb8reQ208TQ) 
