### PR TITLE
AddOnce Listener will be cleared before calling delegates

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignal.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignal.cs
@@ -369,6 +369,108 @@ namespace strange.unittests
             this.testValue += arg1 + arg2 + arg3 + arg4;
         }
 
+		
+		private Signal addOnceZeroArgSignal;
+		[Test]
+        public void AddOnce_SignalWithNoTypeGivenCallbackThatAddsItselfAgain_ExpectsDelegateCalledTwice()
+        {
+			addOnceZeroArgSignal = new Signal();
+            intToIncrement = 0;
+			addOnceZeroArgSignal.AddOnce(ZeroArgCallbackTriggeringAddOnceAgain);
+
+			addOnceZeroArgSignal.Dispatch();
+			addOnceZeroArgSignal.Dispatch();
+
+            Assert.AreEqual(2, intToIncrement);
+        }
+		private void ZeroArgCallbackTriggeringAddOnceAgain()
+		{
+			intToIncrement++;
+			addOnceZeroArgSignal.AddOnce(ZeroArgCallbackTriggeringAddOnceAgain);
+		}
+
+		private Signal<int> addOnceOneArgSignal;
+		[Test]
+        public void AddOnce_SignalWithOneTypeGivenCallbackThatAddsItselfAgain_ExpectsDelegateCalledTwice()
+        {
+			addOnceOneArgSignal = new Signal<int>();
+			addOnceOneArgSignal.AddOnce(OneArgCallbackTriggeringAddOnceAgain);
+
+			CreateOneInt();
+
+			addOnceOneArgSignal.Dispatch(testInt);
+			addOnceOneArgSignal.Dispatch(testInt);
+
+            Assert.AreEqual(2*testInt, testValue);
+        }
+		private void OneArgCallbackTriggeringAddOnceAgain(int testInt)
+		{
+			testValue += testInt;
+			addOnceOneArgSignal.AddOnce(OneArgCallbackTriggeringAddOnceAgain);
+		}
+
+		private Signal<int,int> addOnceTwoArgSignal;
+		[Test]
+        public void AddOnce_SignalWithTwoTypesGivenCallbackThatAddsItselfAgain_ExpectsDelegateCalledTwice()
+        {
+			addOnceTwoArgSignal = new Signal<int, int>();
+			addOnceTwoArgSignal.AddOnce(TwoArgCallbackTriggeringAddOnceAgain);
+
+			CreateTwoInts();
+
+			addOnceTwoArgSignal.Dispatch(testInt, testIntTwo);
+			addOnceTwoArgSignal.Dispatch(testInt, testIntTwo);
+
+            Assert.AreEqual(2*(testInt+testIntTwo), testValue);
+        }
+		private void TwoArgCallbackTriggeringAddOnceAgain(int testInt, int testIntTwo)
+		{
+			testValue += testInt + testIntTwo;
+			addOnceTwoArgSignal.AddOnce(TwoArgCallbackTriggeringAddOnceAgain);
+		}
+
+		private Signal<int,int,int> addOnceThreeArgSignal;
+		[Test]
+        public void AddOnce_SignalWithThreeTypesGivenCallbackThatAddsItselfAgain_ExpectsDelegateCalledTwice()
+        {
+			addOnceThreeArgSignal = new Signal<int, int, int>();
+			addOnceThreeArgSignal.AddOnce(ThreeArgCallbackTriggeringAddOnceAgain);
+
+			CreateThreeInts();
+
+			addOnceThreeArgSignal.Dispatch(testInt, testIntTwo, testIntThree);
+			Console.WriteLine ("1." + testValue);
+			addOnceThreeArgSignal.Dispatch(testInt, testIntTwo, testIntThree);
+
+			Assert.AreEqual(2*(testInt+testIntTwo+testIntThree), testValue);
+        }
+		private void ThreeArgCallbackTriggeringAddOnceAgain(int testInt, int testIntTwo, int testIntThree)
+		{
+			testValue += (testInt + testIntTwo + testIntThree);
+			Console.WriteLine ("?? " + testValue);
+			addOnceThreeArgSignal.AddOnce(ThreeArgCallbackTriggeringAddOnceAgain);
+		}
+
+		private Signal<int,int,int,int> addOnceFourArgSignal;
+		[Test]
+        public void AddOnce_SignalWithFourTypesGivenCallbackThatAddsItselfAgain_ExpectsDelegateCalledTwice()
+        {
+			addOnceFourArgSignal = new Signal<int, int, int, int>();
+			addOnceFourArgSignal.AddOnce(FourArgCallbackTriggeringAddOnceAgain);
+
+			CreateFourInts();
+
+			addOnceFourArgSignal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+			addOnceFourArgSignal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+
+			Assert.AreEqual(2*(testInt+testIntTwo+testIntThree+testIntFour), testValue);
+        }
+		private void FourArgCallbackTriggeringAddOnceAgain(int testInt, int testIntTwo, int testIntThree, int testIntFour)
+		{
+			testValue += testInt + testIntTwo + testIntThree + testIntFour;
+			addOnceFourArgSignal.AddOnce(FourArgCallbackTriggeringAddOnceAgain);
+		}
+
         [Test]
         public void TestRemoveListener()
         {

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
@@ -41,8 +41,9 @@ namespace strange.extensions.signal.impl
 		public void Dispatch(object[] args) 
 		{ 
 			BaseListener(this, args);
-			OnceBaseListener(this, args);
+			var onceBaseDelegates = OnceBaseListener;
 			OnceBaseListener = delegate { };
+			onceBaseDelegates(this, args);
 		}
 
 		public virtual List<Type> GetTypes() { return new List<Type>(); }

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
@@ -93,11 +93,9 @@ namespace strange.extensions.signal.impl
         public void Dispatch()
         {
             Listener();
-            OnceListener();
-            OnceListener = delegate { };
+            CallAndClearOnceListener();
             base.Dispatch(null);
         }
-
         private Action AddUnique(Action listeners, Action callback)
         {
             if (!listeners.GetInvocationList().Contains(callback))
@@ -106,6 +104,12 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+		private void CallAndClearOnceListener ()
+		{
+			var onceListener = OnceListener;
+			OnceListener = delegate { };			
+			onceListener();
+		}        
     }
 
     /// Base concrete form for a Signal with one parameter
@@ -134,8 +138,7 @@ namespace strange.extensions.signal.impl
         public void Dispatch(T type1)
         {
             Listener(type1);
-            OnceListener(type1);
-            OnceListener = delegate { };
+            CallAndClearOnceListener(type1);
             object[] outv = { type1 };
             base.Dispatch(outv);
         }
@@ -148,6 +151,12 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+		private void CallAndClearOnceListener (T type1)
+		{
+			var onceListener = OnceListener;
+			OnceListener = delegate { };			
+			onceListener(type1);
+		}
     }
 
     /// Base concrete form for a Signal with two parameters
@@ -177,8 +186,7 @@ namespace strange.extensions.signal.impl
         public void Dispatch(T type1, U type2)
         {
             Listener(type1, type2);
-            OnceListener(type1, type2);
-            OnceListener = delegate { };
+            CallAndClearOnceListener(type1, type2);
             object[] outv = { type1, type2 };
             base.Dispatch(outv);
         }
@@ -190,6 +198,12 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+		private void CallAndClearOnceListener (T type1, U type2)
+		{
+			var onceListener = OnceListener;
+			OnceListener = delegate { };			
+			onceListener(type1, type2);
+		}        
     }
 
     /// Base concrete form for a Signal with three parameters
@@ -220,8 +234,7 @@ namespace strange.extensions.signal.impl
         public void Dispatch(T type1, U type2, V type3)
         {
             Listener(type1, type2, type3);
-            OnceListener(type1, type2, type3);
-            OnceListener = delegate { };
+            CallAndClearOnceListener(type1, type2, type3);
             object[] outv = { type1, type2, type3 };
             base.Dispatch(outv);
         }
@@ -232,7 +245,13 @@ namespace strange.extensions.signal.impl
                 listeners += callback;
             }
             return listeners;
-        }
+        }		
+		private void CallAndClearOnceListener (T type1, U type2, V type3)
+		{
+			var onceListener = OnceListener;
+			OnceListener = delegate { };			
+			onceListener(type1, type2, type3);
+		}                
     }
 
     /// Base concrete form for a Signal with four parameters
@@ -264,8 +283,7 @@ namespace strange.extensions.signal.impl
         public void Dispatch(T type1, U type2, V type3, W type4)
         {
             Listener(type1, type2, type3, type4);
-            OnceListener(type1, type2, type3, type4);
-            OnceListener = delegate { };
+			CallAndClearOnceListener(type1, type2, type3, type4);
             object[] outv = { type1, type2, type3, type4 };
             base.Dispatch(outv);
         }
@@ -278,6 +296,14 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+        
+		
+		private void CallAndClearOnceListener (T type1, U type2, V type3, W type4)
+		{
+			var onceListener = OnceListener;
+			OnceListener = delegate { };			
+			onceListener(type1, type2, type3, type4);
+		}                
     }
 
 }


### PR DESCRIPTION
Instead of calling OnceDelegates and afterwards clearing the OnceListener delegates list, it will copy them into a temporary variable, clear the OnceListener class event before calling the delegates via the temporary variable. 

This helps in cases where the handle or a subsequent following method might add another AddOnce-Listener to the same signal, which won't be called when the signal gets dispatched again (as the list is cleared afterwards till now).
