### PR TITLE
Add Name attribute to allow named injection into constructors

### DIFF
--- a/Assembly-CSharp-vs.csproj
+++ b/Assembly-CSharp-vs.csproj
@@ -417,5 +417,6 @@
     <Compile Include="StrangeIoC\examples\Assets\scripts\justtests\view\TesterMediator.cs" />
     <Compile Include="StrangeIoC\examples\Assets\scripts\justtests\view\ITesterView.cs" />
     <Compile Include="StrangeIoC\examples\Assets\scripts\multiplecontexts\common\controller\KillAudioListenerCommand.cs" />
+    <Compile Include="StrangeIoC\scripts\strange\.tests\testPayloads\ConstructorNamedInjection.cs" />
   </ItemGroup>
 </Project>

--- a/StrangeIoC/scripts/strange/.tests/extensions/injector/TestInjector.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/injector/TestInjector.cs
@@ -43,6 +43,22 @@ namespace strange.unittests
 		}
 
 		[Test]
+		public void TestConstructorNamedInjection() 
+		{
+			ClassToBeInjected class1 = new ClassToBeInjected();
+			ClassToBeInjected class2 = new ClassToBeInjected();
+			
+			binder.Bind<ClassToBeInjected>().To(class1).ToName("First");
+			binder.Bind<ClassToBeInjected>().To(class2).ToName("Second");
+			binder.Bind<ConstructorNamedInjection>().To<ConstructorNamedInjection>();
+			var instance = binder.GetInstance<ConstructorNamedInjection>() as ConstructorNamedInjection;
+			
+			Assert.That(instance.first.GetType() == typeof(ClassToBeInjected) );
+			Assert.That(instance.second.GetType() == typeof(ClassToBeInjected) );
+			Assert.That(instance.first != instance.second);
+		}
+
+		[Test]
 		public void TestPostConstruct ()
 		{
 			binder.Bind<PostConstructClass> ().To<PostConstructClass> ();

--- a/StrangeIoC/scripts/strange/.tests/extensions/reflector/TestReflectionBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/reflector/TestReflectionBinder.cs
@@ -83,6 +83,14 @@ namespace strange.unittests
 		}
 
 		[Test]
+		public void TestConstructorNamedInjection() 
+		{
+			IReflectedClass reflected = reflector.Get<ConstructorNamedInjection>();
+
+			Assert.That(reflected.ConstructorParameters.Length == 2);
+			Assert.That(reflected.ConstructorParameterNames.Length == 2);
+		}
+
 		public void TestSinglePostConstruct ()
 		{
 			IReflectedClass reflected = reflector.Get<PostConstructClass> ();

--- a/StrangeIoC/scripts/strange/.tests/testPayloads/ConstructorNamedInjection.cs
+++ b/StrangeIoC/scripts/strange/.tests/testPayloads/ConstructorNamedInjection.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace strange.unittests
+{
+	public class ConstructorNamedInjection
+	{
+		public ClassToBeInjected first;
+		public ClassToBeInjected second;
+
+		public ConstructorNamedInjection(
+			[Name("First")] ClassToBeInjected first,
+			[Name("Second")] ClassToBeInjected second)
+		{
+			this.first = first;
+			this.second = second;
+		}
+	}
+}
+

--- a/StrangeIoC/scripts/strange/extensions/injector/InjectAttribute.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/InjectAttribute.cs
@@ -32,6 +32,13 @@
  		public IMyInterface myInstance{get;set;}
 
 
+ * @class Name
+ *  
+ * When a parameter of a constructor or pseudo-constructor is tagged with [Name], 
+ * the injector can discriminate between different classes that satisfy the same interface.  
+ * This means that constructors and pseudo-constructors can used named injection just like 
+ * setter injection.
+ * 
  * @class Construct
  * 
  * The `[Construct]` attribute marks a preferred Constructor. If omitted,
@@ -72,7 +79,21 @@ public class Inject: Attribute
 	public object name{get; set;}
 }
 
-//Tag [PostConstruct] to perform post-injection construction actions
+//Tag [Name] to perform named injection in constructors and pseudo-constructors
+[AttributeUsage(AttributeTargets.Parameter,
+        AllowMultiple = false,
+        Inherited = false)]
+public class Name : Attribute 
+{
+	public Name(object n) 
+	{
+		name = n;
+	}
+
+	public object name { get; set; }
+}
+
+//Tag [Construct] to perform construction injection
 [AttributeUsage(AttributeTargets.Constructor, 
 		AllowMultiple = false,
 		Inherited = true)]

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/Injector.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/Injector.cs
@@ -92,12 +92,14 @@ namespace strange.extensions.injector.impl
 				
 				IReflectedClass reflection = reflector.Get (reflectionType);
 
-				Type[] parameters = reflection.constructorParameters;
-				int aa = parameters.Length;
+				Type[] parameterTypes = reflection.constructorParameters;
+				object[] parameterNames = reflection.ConstructorParameterNames;
+
+				int aa = parameterTypes.Length;
 				object[] args = new object [aa];
 				for (int a = 0; a < aa; a++)
 				{
-					args [a] = getValueInjection (parameters[a] as Type, null, null);
+					args [a] = getValueInjection (parameterTypes[a] as Type, parameterNames[a], null);
 				}
 				retv = factory.Get (binding, args);
 
@@ -176,12 +178,14 @@ namespace strange.extensions.injector.impl
 			ConstructorInfo constructor = reflection.constructor;
 			failIf(constructor == null, "Attempt to construction inject a null constructor", InjectionExceptionType.NULL_CONSTRUCTOR);
 
-			Type[] constructorParameters = reflection.constructorParameters;
-			object[] values = new object[constructorParameters.Length];
+			Type[] parameterTypes = reflection.constructorParameters;
+			object[] parameterNames = reflection.ConstructorParameterNames;
+			object[] values = new object[parameterTypes.Length];
+
 			int i = 0;
-			foreach (Type type in constructorParameters)
+			foreach (Type type in parameterTypes)
 			{
-				values[i] = getValueInjection(type, null, target);
+				values[i] = getValueInjection(type, parameterNames[i], target);
 				i++;
 			}
 			if (values.Length == 0)

--- a/StrangeIoC/scripts/strange/extensions/reflector/api/IReflectedClass.cs
+++ b/StrangeIoC/scripts/strange/extensions/reflector/api/IReflectedClass.cs
@@ -37,6 +37,7 @@ namespace strange.extensions.reflector.api
 
 		/// Get/set the preferred constructor's list of parameters
 		Type[] ConstructorParameters{ get; set;}
+		object[] ConstructorParameterNames { get; set; }
 
 		/// Get/set any PostConstructors. This includes inherited PostConstructors.
 		MethodInfo[] PostConstructors{ get; set;}

--- a/StrangeIoC/scripts/strange/extensions/reflector/impl/ReflectedClass.cs
+++ b/StrangeIoC/scripts/strange/extensions/reflector/impl/ReflectedClass.cs
@@ -35,6 +35,7 @@ namespace strange.extensions.reflector.impl
 	{
 		public ConstructorInfo Constructor{ get; set;}
 		public Type[] ConstructorParameters{ get; set;}
+		public object[] ConstructorParameterNames { get; set; }
 		public MethodInfo[] PostConstructors{ get; set;}
 		public KeyValuePair<Type, PropertyInfo>[] Setters{ get; set;}
 		public object[] SetterNames{ get; set;}

--- a/StrangeIoC/scripts/strange/extensions/reflector/impl/ReflectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/reflector/impl/ReflectionBinder.cs
@@ -85,15 +85,23 @@ namespace strange.extensions.reflector.impl
 
 
 			Type[] paramList = new Type[parameters.Length];
+			object[] names = new object[parameters.Length];
 			int i = 0;
 			foreach (ParameterInfo param in parameters)
 			{
 				Type paramType = param.ParameterType;
 				paramList [i] = paramType;
+
+				object[] attributes = param.GetCustomAttributes(typeof(Name), false);
+				if (attributes.Length > 0) 
+				{
+					names[i] = ( (Name)attributes[0]).name;
+				}
 				i++;
 			}
 			reflected.Constructor = constructor;
 			reflected.ConstructorParameters = paramList;
+			reflected.ConstructorParameterNames = names;
 		}
 
 		//Look for a constructor in the order:


### PR DESCRIPTION
## The [Name] attribute
I extended Strange to include an additional attribute, [Name].  When a parameter of a constructor is tagged with [Name], the injector can discriminate between different classes that satisfy the same interface.  Here is an example:
```
public class PrintClass {
  private IPrinter printer;

 [Construct]
  public PrintClass([Name("ConsolePrinter")] IPrinter printer) {
    this.printer = printer;
  }
}
```

I've been using [Name] in my personal projects and it's been incredibly useful so far, and I think it's something other people would find useful too.  This feature comes with with its own unit tests that pass along with the existing test suite.
