### PR TITLE
Feature/listens to

### DIFF
--- a/Assembly-CSharp-vs.csproj
+++ b/Assembly-CSharp-vs.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -63,22 +63,7 @@
       </Properties>
     </MonoDevelop>
   </ProjectExtensions>
-  <ItemGroup>
-    <Folder Include="StrangeIoC\" />
-    <Folder Include="StrangeIoC\examples\" />
-    <Folder Include="StrangeIoC\scripts\strange\extensions\signal\" />
-    <Folder Include="StrangeIoC\scripts\strange\.tests\" />
-    <Folder Include="StrangeIoC\scripts\strange\extensions\pool\" />
-    <Folder Include="StrangeIoC\scripts\strange\extensions\pool\api\" />
-    <Folder Include="StrangeIoC\scripts\strange\extensions\pool\impl\" />
-    <Folder Include="StrangeIoC\scripts\strange\.tests\extensions\pool\" />
-    <Folder Include="StrangeIoC\examples\Assets\scripts\signalsproject\" />
-    <Folder Include="StrangeIoC\scripts\strange\extensions\implicitBind\" />
-    <Folder Include="StrangeIoC\examples\Assets\scripts\justtests\" />
-    <Folder Include="StrangeIoC\examples\Assets\scripts\justtests\view\" />
-    <Folder Include="StrangeIoC\examples\Assets\scripts\multiplecontexts\common\" />
-    <Folder Include="StrangeIoC\examples\Assets\scripts\multiplecontexts\common\controller\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <None Include="StrangeIoC\scripts\strange\extensions\context\api\ContextEvent.cs.meta" />
     <None Include="StrangeIoC\scripts\strange\extensions\context\api\ContextExceptionType.cs.meta" />
@@ -214,6 +199,7 @@
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\MediationException.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\Mediator.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\View.cs" />
+    <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\ListensTo.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\reflector\api\IReflectedClass.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\reflector\api\IReflectionBinder.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\reflector\api\ReflectionExceptionType.cs" />

--- a/Assembly-CSharp-vs.csproj
+++ b/Assembly-CSharp-vs.csproj
@@ -200,6 +200,7 @@
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\Mediator.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\View.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\ListensTo.cs" />
+    <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\SignalMediationBinder.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\reflector\api\IReflectedClass.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\reflector\api\IReflectionBinder.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\reflector\api\ReflectionExceptionType.cs" />

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
@@ -42,7 +42,6 @@ namespace strange.extensions.injector.impl
 			injector = new Injector ();
 			injector.binder = this;
 			injector.reflector = new ReflectionBinder();
-			Bind<IReflectionBinder>().ToValue(injector.reflector);
 		}
 
 		public object GetInstance(Type key)

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
@@ -25,6 +25,7 @@
 
 using System;
 using System.Collections.Generic;
+using strange.extensions.reflector.api;
 using strange.framework.api;
 using strange.extensions.injector.api;
 using strange.extensions.reflector.impl;
@@ -40,7 +41,8 @@ namespace strange.extensions.injector.impl
 		{
 			injector = new Injector ();
 			injector.binder = this;
-			injector.reflector = new ReflectionBinder ();
+			injector.reflector = new ReflectionBinder();
+			Bind<IReflectionBinder>().ToValue(injector.reflector);
 		}
 
 		public object GetInstance(Type key)

--- a/StrangeIoC/scripts/strange/extensions/mediation/ListensTo.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/ListensTo.cs
@@ -1,0 +1,16 @@
+﻿	using System;
+
+[AttributeUsage(AttributeTargets.Method, 
+		AllowMultiple = false,
+		Inherited = true)]
+public class ListensTo: Attribute
+{
+	public ListensTo(){}
+
+	public ListensTo(Type t)
+	{
+		type = t;
+	}
+	
+	public Type type {get; set;}
+}

--- a/StrangeIoC/scripts/strange/extensions/mediation/ListensTo.cs.meta
+++ b/StrangeIoC/scripts/strange/extensions/mediation/ListensTo.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a0c7460240766064b81affbc06adefc4
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Reflection;
 using strange.extensions.mediation.api;
 using strange.extensions.mediation.impl;
@@ -19,32 +18,56 @@ namespace strange.extensions.mediation
             MonoBehaviour mediator = base.createMediator(mono, mediatorType);
             if (mediator is IMediator)
             {
-                IReflectedClass reflectedClass = reflectionBinder.Get(mediatorType);
-
-                //Let's GetInstance some Signals and add listeners
-
-                foreach (var pair in reflectedClass.attrMethods)
-                {
-                    if (pair.Value is ListensTo)
-                    {
-                        ListensTo attr = (ListensTo) pair.Value;
-                        ISignal signal = (ISignal) injectionBinder.GetInstance(attr.type);
-
-                        AssignDelegate(mediator, signal, pair.Key);
-                    }
-                }
-
-
+                HandleDelegates(mediator, mediatorType, true);
             }
             return mediator;
+        }
+
+        private void HandleDelegates(MonoBehaviour mono, Type mediatorType, bool toAdd)
+        {
+            IReflectedClass reflectedClass = reflectionBinder.Get(mediatorType);
+
+            //Let's GetInstance some Signals and add listeners
+
+            foreach (var pair in reflectedClass.attrMethods)
+            {
+                if (pair.Value is ListensTo)
+                {
+                    ListensTo attr = (ListensTo)pair.Value;
+                    ISignal signal = (ISignal)injectionBinder.GetInstance(attr.type);
+                    if (toAdd)
+                        AssignDelegate(mono, signal, pair.Key);
+                    else
+                        RemoveDelegate(mono, signal, pair.Key);
+                }
+            }
+        }
+
+        private void RemoveDelegate(MonoBehaviour mediator, ISignal signal, MethodInfo method)
+        {
+            if (signal.GetType().BaseType.IsGenericType) //e.g. Signal<T>, Signal<T,U> etc.
+            {
+                Delegate toRemove = Delegate.CreateDelegate(signal.listener.GetType(), mediator, method);
+                signal.listener = Delegate.Remove(signal.listener,toRemove);
+            }
+            else
+            {
+                ((Signal)signal).RemoveListener((Action)Delegate.CreateDelegate(typeof(Action), mediator, method)); //Assign and cast explicitly for Type == Signal case
+            }
+
         }
 
         private void AssignDelegate(MonoBehaviour mediator, ISignal signal, MethodInfo method)
         {
             if (signal.GetType().BaseType.IsGenericType)
+            {
                 signal.listener = Delegate.CreateDelegate(signal.listener.GetType(), mediator, method); //e.g. Signal<T>, Signal<T,U> etc.
+            }
             else
+            {
                 ((Signal)signal).AddListener((Action)Delegate.CreateDelegate(typeof(Action), mediator, method)); //Assign and cast explicitly for Type == Signal case
+            }
+
         }
 
 
@@ -52,6 +75,8 @@ namespace strange.extensions.mediation
         protected override void removeMediator(IMediator mediator)
         {
             //Unbind signals to methods
+            HandleDelegates((MonoBehaviour)mediator, mediator.GetType(), false);
+
             base.removeMediator(mediator);
         }
     }

--- a/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using strange.extensions.mediation.api;
+using strange.extensions.mediation.impl;
+using strange.extensions.reflector.api;
+using strange.extensions.signal.impl;
+using UnityEngine;
+
+namespace strange.extensions.mediation
+{
+    public class SignalMediationBinder : MediationBinder
+    {
+        [Inject]
+        public IReflectionBinder reflectionBinder { get; set; }
+
+        protected override MonoBehaviour createMediator(MonoBehaviour mono, Type mediatorType)
+        {
+            MonoBehaviour mediator = base.createMediator(mono, mediatorType);
+            if (mediator is IMediator)
+            {
+                IReflectedClass reflectedClass = reflectionBinder.Get(mediatorType);
+
+                //Let's GetInstance some Signals and add listeners
+
+                foreach (var pair in reflectedClass.attrMethods)
+                {
+                    if (pair.Value is ListensTo)
+                    {
+                        ListensTo attr = (ListensTo) pair.Value;
+                        ISignal signal = (ISignal) injectionBinder.GetInstance(attr.type);
+
+                        AssignDelegate(mediator, signal, pair.Key);
+                    }
+                }
+
+
+            }
+            return mediator;
+        }
+
+        private void AssignDelegate(MonoBehaviour mediator, ISignal signal, MethodInfo method)
+        {
+            if (signal.GetType().BaseType.IsGenericType)
+                signal.listener = Delegate.CreateDelegate(signal.listener.GetType(), mediator, method); //e.g. Signal<T>, Signal<T,U> etc.
+            else
+                ((Signal)signal).AddListener((Action)Delegate.CreateDelegate(typeof(Action), mediator, method)); //Assign and cast explicitly for Type == Signal case
+        }
+
+
+
+        protected override void removeMediator(IMediator mediator)
+        {
+            //Unbind signals to methods
+            base.removeMediator(mediator);
+        }
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
@@ -10,8 +10,6 @@ namespace strange.extensions.mediation
 {
     public class SignalMediationBinder : MediationBinder
     {
-        [Inject]
-        public IReflectionBinder reflectionBinder { get; set; }
 
         protected override MonoBehaviour createMediator(MonoBehaviour mono, Type mediatorType)
         {
@@ -25,7 +23,7 @@ namespace strange.extensions.mediation
 
         private void HandleDelegates(MonoBehaviour mono, Type mediatorType, bool toAdd)
         {
-            IReflectedClass reflectedClass = reflectionBinder.Get(mediatorType);
+            IReflectedClass reflectedClass = injectionBinder.injector.reflector.Get(mediatorType);
 
             //Let's GetInstance some Signals and add listeners
 

--- a/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs.meta
+++ b/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87ea9cfe0593e2542940b14bc384cb98
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -97,6 +97,7 @@ namespace strange.extensions.mediation.impl
 				}
 			}
 			injectionBinder.injector.Inject (mono, false);
+
 		}
 
 		new public IMediationBinding Bind<T> ()
@@ -127,7 +128,7 @@ namespace strange.extensions.mediation.impl
 					{
 						throw new MediationException(viewType + "mapped to itself. The result would be a stack overflow.", MediationExceptionType.MEDIATOR_VIEW_STACK_OVERFLOW);
 					}
-					MonoBehaviour mediator = mono.gameObject.AddComponent(mediatorType) as MonoBehaviour;
+					MonoBehaviour mediator = createMediator(mono, mediatorType);
 					if (mediator == null)
 						throw new MediationException ("The view: " + viewType.ToString() + " is mapped to mediator: " + mediatorType.ToString() + ". AddComponent resulted in null, which probably means " + mediatorType.ToString().Substring(mediatorType.ToString().LastIndexOf(".")+1) + " is not a MonoBehaviour.", MediationExceptionType.NULL_MEDIATOR);
 					if (mediator is IMediator)
@@ -139,8 +140,20 @@ namespace strange.extensions.mediation.impl
 					injectionBinder.Unbind(typeToInject);
 					if (mediator is IMediator)
 						((IMediator)mediator).OnRegister ();
+
+
 				}
 			}
+		}
+
+		virtual protected MonoBehaviour createMediator(MonoBehaviour mono, Type mediatorType)
+		{
+			return mono.gameObject.AddComponent(mediatorType) as MonoBehaviour;
+		}
+
+		virtual protected void removeMediator(IMediator mediator)
+		{
+			mediator.OnRemove();
 		}
 
 		/// Removes a mediator when its view is destroyed
@@ -159,7 +172,7 @@ namespace strange.extensions.mediation.impl
 					IMediator mediator = mono.GetComponent(mediatorType) as IMediator;
 					if (mediator != null)
 					{
-						mediator.OnRemove();
+						removeMediator(mediator);
 					}
 				}
 			}

--- a/StrangeIoC/scripts/strange/extensions/reflector/api/IReflectedClass.cs
+++ b/StrangeIoC/scripts/strange/extensions/reflector/api/IReflectedClass.cs
@@ -61,6 +61,8 @@ namespace strange.extensions.reflector.api
 		object[] setterNames{ get; set;}
 		/// [Obsolete"Strange migration to conform to C# guidelines. Removing camelCased publics"]
 		bool preGenerated{ get; set;}
+
+	    bool hasSetterFor(Type type);
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/reflector/api/IReflectedClass.cs
+++ b/StrangeIoC/scripts/strange/extensions/reflector/api/IReflectedClass.cs
@@ -25,6 +25,7 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -55,6 +56,11 @@ namespace strange.extensions.reflector.api
 		Type[] constructorParameters{ get; set;}
 		/// [Obsolete"Strange migration to conform to C# guidelines. Removing camelCased publics"]
 		MethodInfo[] postConstructors{ get; set;}
+
+		/// MethodInfo to Attribute
+		/// Any attributed method is in this collection, including postconstructs
+		KeyValuePair<MethodInfo, Attribute>[] attrMethods { get; set; }
+
 		/// [Obsolete"Strange migration to conform to C# guidelines. Removing camelCased publics"]
 		KeyValuePair<Type, PropertyInfo>[] setters{ get; set;}
 		/// [Obsolete"Strange migration to conform to C# guidelines. Removing camelCased publics"]
@@ -62,7 +68,8 @@ namespace strange.extensions.reflector.api
 		/// [Obsolete"Strange migration to conform to C# guidelines. Removing camelCased publics"]
 		bool preGenerated{ get; set;}
 
-	    bool hasSetterFor(Type type);
+
+		bool hasSetterFor(Type type);
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/reflector/api/ReflectionExceptionType.cs
+++ b/StrangeIoC/scripts/strange/extensions/reflector/api/ReflectionExceptionType.cs
@@ -25,6 +25,9 @@ namespace strange.extensions.reflector.api
 
 		/// The reflector is not allowed to inject into private/protected setters.
 		CANNOT_INJECT_INTO_NONPUBLIC_SETTER,
+
+		/// ListensTo attribute must have a matching Inject tag for the Signal in question
+		LISTENS_TO_MUST_HAVE_INJECTION,
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/reflector/impl/ReflectedClass.cs
+++ b/StrangeIoC/scripts/strange/extensions/reflector/impl/ReflectedClass.cs
@@ -44,7 +44,8 @@ namespace strange.extensions.reflector.impl
 		public ConstructorInfo constructor{ get { return Constructor; } set { Constructor = value; }}
 		public Type[] constructorParameters{ get { return ConstructorParameters; } set { ConstructorParameters = value; }}
 		public MethodInfo[] postConstructors{ get { return PostConstructors; } set { PostConstructors = value; }}
-		public KeyValuePair<Type, PropertyInfo>[] setters{ get { return Setters; } set { Setters = value; }}
+	    public KeyValuePair<MethodInfo, Attribute>[] attrMethods { get; set; }
+	    public KeyValuePair<Type, PropertyInfo>[] setters{ get { return Setters; } set { Setters = value; }}
 		public object[] setterNames{ get { return SetterNames; } set { SetterNames = value; }}
 		public bool preGenerated{ get { return PreGenerated; } set { PreGenerated = value; }}
 

--- a/StrangeIoC/scripts/strange/extensions/reflector/impl/ReflectedClass.cs
+++ b/StrangeIoC/scripts/strange/extensions/reflector/impl/ReflectedClass.cs
@@ -47,6 +47,18 @@ namespace strange.extensions.reflector.impl
 		public KeyValuePair<Type, PropertyInfo>[] setters{ get { return Setters; } set { Setters = value; }}
 		public object[] setterNames{ get { return SetterNames; } set { SetterNames = value; }}
 		public bool preGenerated{ get { return PreGenerated; } set { PreGenerated = value; }}
+
+	    public bool hasSetterFor(Type type)
+	    {
+	        foreach (KeyValuePair<Type, PropertyInfo> setterType in setters)
+	        {
+	            if (setterType.Key == type)
+	            {
+	                return true;
+	            }
+	        }
+	        return false;
+	    }
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
@@ -70,8 +70,12 @@ using System.Linq;
 
 namespace strange.extensions.signal.impl
 {
+    public interface ISignal
+    {
+        Delegate listener { get; set; }
+    }
     /// Base concrete form for a Signal with no parameters
-    public class Signal : BaseSignal
+    public class Signal : BaseSignal, ISignal
     {
         public event Action Listener = delegate { };
         public event Action OnceListener = delegate { };
@@ -106,10 +110,12 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+
+        public Delegate listener { get { return Listener; } set { Listener = (Action) value; }}
     }
 
     /// Base concrete form for a Signal with one parameter
-    public class Signal<T> : BaseSignal
+    public class Signal<T> : BaseSignal, ISignal
     {
         public event Action<T> Listener = delegate { };
         public event Action<T> OnceListener = delegate { };
@@ -148,10 +154,12 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+
+        public Delegate listener { get { return Listener; } set { Listener = (Action<T>) value; } }
     }
 
     /// Base concrete form for a Signal with two parameters
-    public class Signal<T, U> : BaseSignal
+    public class Signal<T, U> : BaseSignal, ISignal
     {
         public event Action<T, U> Listener = delegate { };
         public event Action<T, U> OnceListener = delegate { };
@@ -190,10 +198,12 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+
+        public Delegate listener { get { return Listener; } set { Listener = (Action<T, U>) value; } }
     }
 
     /// Base concrete form for a Signal with three parameters
-    public class Signal<T, U, V> : BaseSignal
+    public class Signal<T, U, V> : BaseSignal, ISignal
     {
         public event Action<T, U, V> Listener = delegate { };
         public event Action<T, U, V> OnceListener = delegate { };
@@ -233,10 +243,12 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+
+        public Delegate listener { get { return Listener; } set { Listener = (Action<T, U, V>) value; } }
     }
 
     /// Base concrete form for a Signal with four parameters
-    public class Signal<T, U, V, W> : BaseSignal
+    public class Signal<T, U, V, W> : BaseSignal, ISignal
     {
         public event Action<T, U, V, W> Listener = delegate { };
         public event Action<T, U, V, W> OnceListener = delegate { };
@@ -278,6 +290,8 @@ namespace strange.extensions.signal.impl
             }
             return listeners;
         }
+
+        public Delegate listener { get { return Listener; } set { Listener = (Action<T, U, V, W>) value; } }
     }
 
 }


### PR DESCRIPTION
Could use some feedback on this feature.

This is meant to reduce boilerplate from creation of mediators.

<b>This:</b>
[Inject]
public MySignal MySignal { get; set; }
[Inject]
public MyOtherSignal MyOtherSignal { get; set; }

public override OnRegister()
{
    MySignal.AddListener(MyCallback);
    MyOtherSignal.AddListener(MyOtherCallback);
}

//callbacks
public override OnRemove()
{
    MySignal.RemoveListener(MyCallback);
    MyOtherSIgnal.RemoveListener(MyCallback);
} 

<b>Becomes:</b>
[ListensTo(typeof(MySignal)]
public void MyListener()

[ListensTo(typeof(MyPayloadSignal>)]
public void MyPayloadListener(float r, float g, float b)


<b>Required in context: </b>
injector.Unbind`<IMediationBinder>`();
injector.Bind`<IMediationBinder>`().To`<SignalMediationBinder>`().ToSingleton();

Keep in mind <b> your signals must already be bound</b> It is not the domain of this extension to auto inject those signals. And an [Implements] class annotation takes two seconds. This is just meant to alleviate some of your time spent writing stale mediator code.

Re: order of operations: This is adding and removing listeners before OnRegister and before OnRemove.

Be forewarned! This is potentially slow! I think I'll create an ISignalMediator interface and check for that to avoid unnecessary reflection. Reflection is <b>slow</b>, so it is not recommended to use this for objects which are being created/destroyed regularly! I may cache some more values, as well. The signal values should be cached and I can write a few no-brainer optimizations in loops and property lookups I'm sure. I guess my point is use some common sense :)


