### PR TITLE
Feature/remove all signal listeners

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignal.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignal.cs
@@ -383,6 +383,23 @@ namespace strange.unittests
             signal.Dispatch(testInt);
             Assert.AreEqual(testInt, testValue);
         }
+        
+        [Test]
+        public void TestRemoveAllListeners() {
+            Signal<int> signal = new Signal<int>();
+
+            signal.AddListener(OneArgSignalCallback);
+            signal.AddListener(OneArgSignalCallback);
+            signal.AddListener(OneArgSignalCallback);
+            signal.AddListener(OneArgSignalCallback);
+
+            signal.Dispatch(testInt);
+            Assert.AreEqual(testValue, testIntFour);
+
+            signal.RemoveAllListeners();
+            signal.Dispatch(testValue);
+            Assert.AreEqual(testValue, testIntFour);
+        }
 
         [Test]
         public void RemoveListener_NoType_ExpectsListenerRemoved()

--- a/StrangeIoC/scripts/strange/extensions/signal/api/IBaseSignal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/api/IBaseSignal.cs
@@ -69,6 +69,9 @@ namespace strange.extensions.signal.api
 
 		/// Remove a callback from this Signal
 		void RemoveListener(Action<IBaseSignal, object[]> callback);
+		
+		/// Remove all callbacks from this Signal
+		void RemoveAllListeners();
 
 		/// Returns a List<System.Type> representing the Types bindable to this Signal
 		List<Type> GetTypes();

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
@@ -27,19 +27,15 @@ using System;
 using strange.extensions.signal.api;
 using System.Collections.Generic;
 
-namespace strange.extensions.signal.impl
-{
-	public class BaseSignal : IBaseSignal
-	{
-        
+namespace strange.extensions.signal.impl {
+	public class BaseSignal : IBaseSignal {
 		/// The delegate for repeating listeners
 		public event Action<IBaseSignal, object[]> BaseListener = delegate { };
 
 		/// The delegate for one-off listeners
 		public event Action<IBaseSignal, object[]> OnceBaseListener = delegate { };
 
-		public void Dispatch(object[] args) 
-		{ 
+		public void Dispatch(object[] args) {
 			BaseListener(this, args);
 			OnceBaseListener(this, args);
 			OnceBaseListener = delegate { };
@@ -47,10 +43,8 @@ namespace strange.extensions.signal.impl
 
 		public virtual List<Type> GetTypes() { return new List<Type>(); }
 
-		public void AddListener(Action<IBaseSignal, object[]> callback) 
-		{
-			foreach (Delegate del in BaseListener.GetInvocationList())
-			{
+		public void AddListener(Action<IBaseSignal, object[]> callback) {
+			foreach (Delegate del in BaseListener.GetInvocationList()) {
 				Action<IBaseSignal, object[]> action = (Action<IBaseSignal, object[]>)del;
 				if (callback.Equals(action)) //If this callback exists already, ignore this addlistener
 					return;
@@ -59,21 +53,19 @@ namespace strange.extensions.signal.impl
 			BaseListener += callback;
 		}
 
-		public void AddOnce(Action<IBaseSignal, object[]> callback)
-		{
-			foreach (Delegate del in OnceBaseListener.GetInvocationList())
-			{
+		public void AddOnce(Action<IBaseSignal, object[]> callback) {
+			foreach (Delegate del in OnceBaseListener.GetInvocationList()) {
 				Action<IBaseSignal, object[]> action = (Action<IBaseSignal, object[]>)del;
 				if (callback.Equals(action)) //If this callback exists already, ignore this addlistener
 					return;
 			}
-
 			OnceBaseListener += callback;
 		}
 
 		public void RemoveListener(Action<IBaseSignal, object[]> callback) { BaseListener -= callback; }
 
-	   
+		public virtual void RemoveAllListeners() { BaseListener = delegate { }; }
+
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
@@ -27,15 +27,19 @@ using System;
 using strange.extensions.signal.api;
 using System.Collections.Generic;
 
-namespace strange.extensions.signal.impl {
-	public class BaseSignal : IBaseSignal {
+namespace strange.extensions.signal.impl
+{
+	public class BaseSignal : IBaseSignal
+	{
+		
 		/// The delegate for repeating listeners
 		public event Action<IBaseSignal, object[]> BaseListener = delegate { };
 
 		/// The delegate for one-off listeners
 		public event Action<IBaseSignal, object[]> OnceBaseListener = delegate { };
 
-		public void Dispatch(object[] args) {
+		public void Dispatch(object[] args) 
+		{ 
 			BaseListener(this, args);
 			OnceBaseListener(this, args);
 			OnceBaseListener = delegate { };
@@ -43,8 +47,10 @@ namespace strange.extensions.signal.impl {
 
 		public virtual List<Type> GetTypes() { return new List<Type>(); }
 
-		public void AddListener(Action<IBaseSignal, object[]> callback) {
-			foreach (Delegate del in BaseListener.GetInvocationList()) {
+		public void AddListener(Action<IBaseSignal, object[]> callback) 
+		{
+			foreach (Delegate del in BaseListener.GetInvocationList())
+			{
 				Action<IBaseSignal, object[]> action = (Action<IBaseSignal, object[]>)del;
 				if (callback.Equals(action)) //If this callback exists already, ignore this addlistener
 					return;
@@ -53,19 +59,20 @@ namespace strange.extensions.signal.impl {
 			BaseListener += callback;
 		}
 
-		public void AddOnce(Action<IBaseSignal, object[]> callback) {
-			foreach (Delegate del in OnceBaseListener.GetInvocationList()) {
+		public void AddOnce(Action<IBaseSignal, object[]> callback)
+		{
+			foreach (Delegate del in OnceBaseListener.GetInvocationList())
+			{
 				Action<IBaseSignal, object[]> action = (Action<IBaseSignal, object[]>)del;
 				if (callback.Equals(action)) //If this callback exists already, ignore this addlistener
 					return;
 			}
+
 			OnceBaseListener += callback;
 		}
 
 		public void RemoveListener(Action<IBaseSignal, object[]> callback) { BaseListener -= callback; }
 
 		public virtual void RemoveAllListeners() { BaseListener = delegate { }; }
-
 	}
 }
-

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
@@ -46,8 +46,8 @@
 
 		//SIGNAL WITH PARAMETERS
 		//Create a new signal with two parameters
- 		Signal<int, string> signal = new Signal<int, string>();
- 		//Add a listener
+		Signal<int, string> signal = new Signal<int, string>();
+		//Add a listener
 		signal.AddListener(callbackWithParamsIntAndString);
 		//Add a listener for the duration of precisely one Dispatch
 		signal.AddOnce(anotherCallbackWithParamsIntAndString);
@@ -66,218 +66,119 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
-namespace strange.extensions.signal.impl
-{
-    /// Base concrete form for a Signal with no parameters
-    public class Signal : BaseSignal
-    {
-        public event Action Listener = delegate { };
-        public event Action OnceListener = delegate { };
+namespace strange.extensions.signal.impl {
+	/// Base concrete form for a Signal with no parameters
+	public class Signal : BaseSignal {
+		public event Action Listener = delegate { };
+		public event Action OnceListener = delegate { };
+		public void AddListener(Action callback) { Listener += callback; }
+		public void AddOnce(Action callback) { OnceListener += callback; }
+		public void RemoveListener(Action callback) { Listener -= callback; }
+		public override void RemoveAllListeners() { Listener = delegate { }; }
+		public override List<Type> GetTypes() {
+			return new List<Type>();
+		}
+		public void Dispatch() {
+			Listener();
+			OnceListener();
+			OnceListener = delegate { };
+			base.Dispatch(null);
+		}
+	}
 
-        public void AddListener(Action callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
+	/// Base concrete form for a Signal with one parameter
+	public class Signal<T> : BaseSignal {
+		public event Action<T> Listener = delegate { };
+		public event Action<T> OnceListener = delegate { };
+		public void AddListener(Action<T> callback) { Listener += callback; }
+		public void AddOnce(Action<T> callback) { OnceListener += callback; }
+		public void RemoveListener(Action<T> callback) { Listener -= callback; }
+		public override void RemoveAllListeners() { Listener = delegate { }; }
+		public override List<Type> GetTypes() {
+			List<Type> retv = new List<Type>();
+			retv.Add(typeof(T));
+			return retv;
+		}
+		public void Dispatch(T type1) {
+			Listener(type1);
+			OnceListener(type1);
+			OnceListener = delegate { };
+			object[] outv = { type1 };
+			base.Dispatch(outv);
+		}
+	}
 
-        public void AddOnce(Action callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
-        public void RemoveListener(Action callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            return new List<Type>();
-        }
-        public void Dispatch()
-        {
-            Listener();
-            OnceListener();
-            OnceListener = delegate { };
-            base.Dispatch(null);
-        }
+	/// Base concrete form for a Signal with two parameters
+	public class Signal<T, U> : BaseSignal {
+		public event Action<T, U> Listener = delegate { };
+		public event Action<T, U> OnceListener = delegate { };
+		public void AddListener(Action<T, U> callback) { Listener += callback; }
+		public void AddOnce(Action<T, U> callback) { OnceListener += callback; }
+		public void RemoveListener(Action<T, U> callback) { Listener -= callback; }
+		public override void RemoveAllListeners() { Listener = delegate { }; }
+		public override List<Type> GetTypes() {
+			List<Type> retv = new List<Type>();
+			retv.Add(typeof(T));
+			retv.Add(typeof(U));
+			return retv;
+		}
+		public void Dispatch(T type1, U type2) {
+			Listener(type1, type2);
+			OnceListener(type1, type2);
+			OnceListener = delegate { };
+			object[] outv = { type1, type2 };
+			base.Dispatch(outv);
+		}
+	}
 
-        private Action AddUnique(Action listeners, Action callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
-    }
+	/// Base concrete form for a Signal with three parameters
+	public class Signal<T, U, V> : BaseSignal {
+		public event Action<T, U, V> Listener = delegate { };
+		public event Action<T, U, V> OnceListener = delegate { };
+		public void AddListener(Action<T, U, V> callback) { Listener += callback; }
+		public void AddOnce(Action<T, U, V> callback) { OnceListener += callback; }
+		public void RemoveListener(Action<T, U, V> callback) { Listener -= callback; }
+		public override void RemoveAllListeners() { Listener = delegate { }; }
+		public override List<Type> GetTypes() {
+			List<Type> retv = new List<Type>();
+			retv.Add(typeof(T));
+			retv.Add(typeof(U));
+			retv.Add(typeof(V));
+			return retv;
+		}
+		public void Dispatch(T type1, U type2, V type3) {
+			Listener(type1, type2, type3);
+			OnceListener(type1, type2, type3);
+			OnceListener = delegate { };
+			object[] outv = { type1, type2, type3 };
+			base.Dispatch(outv);
+		}
+	}
 
-    /// Base concrete form for a Signal with one parameter
-    public class Signal<T> : BaseSignal
-    {
-        public event Action<T> Listener = delegate { };
-        public event Action<T> OnceListener = delegate { };
-
-        public void AddListener(Action<T> callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
-
-        public void AddOnce(Action<T> callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
-
-        public void RemoveListener(Action<T> callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            List<Type> retv = new List<Type>();
-            retv.Add(typeof(T));
-            return retv;
-        }
-        public void Dispatch(T type1)
-        {
-            Listener(type1);
-            OnceListener(type1);
-            OnceListener = delegate { };
-            object[] outv = { type1 };
-            base.Dispatch(outv);
-        }
-
-        private Action<T> AddUnique(Action<T> listeners, Action<T> callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
-    }
-
-    /// Base concrete form for a Signal with two parameters
-    public class Signal<T, U> : BaseSignal
-    {
-        public event Action<T, U> Listener = delegate { };
-        public event Action<T, U> OnceListener = delegate { };
-
-        public void AddListener(Action<T, U> callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
-
-        public void AddOnce(Action<T, U> callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
-
-        public void RemoveListener(Action<T, U> callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            List<Type> retv = new List<Type>();
-            retv.Add(typeof(T));
-            retv.Add(typeof(U));
-            return retv;
-        }
-        public void Dispatch(T type1, U type2)
-        {
-            Listener(type1, type2);
-            OnceListener(type1, type2);
-            OnceListener = delegate { };
-            object[] outv = { type1, type2 };
-            base.Dispatch(outv);
-        }
-        private Action<T, U> AddUnique(Action<T, U> listeners, Action<T, U> callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
-    }
-
-    /// Base concrete form for a Signal with three parameters
-    public class Signal<T, U, V> : BaseSignal
-    {
-        public event Action<T, U, V> Listener = delegate { };
-        public event Action<T, U, V> OnceListener = delegate { };
-
-        public void AddListener(Action<T, U, V> callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
-
-        public void AddOnce(Action<T, U, V> callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
-
-        public void RemoveListener(Action<T, U, V> callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            List<Type> retv = new List<Type>();
-            retv.Add(typeof(T));
-            retv.Add(typeof(U));
-            retv.Add(typeof(V));
-            return retv;
-        }
-        public void Dispatch(T type1, U type2, V type3)
-        {
-            Listener(type1, type2, type3);
-            OnceListener(type1, type2, type3);
-            OnceListener = delegate { };
-            object[] outv = { type1, type2, type3 };
-            base.Dispatch(outv);
-        }
-        private Action<T, U, V> AddUnique(Action<T, U, V> listeners, Action<T, U, V> callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
-    }
-
-    /// Base concrete form for a Signal with four parameters
-    public class Signal<T, U, V, W> : BaseSignal
-    {
-        public event Action<T, U, V, W> Listener = delegate { };
-        public event Action<T, U, V, W> OnceListener = delegate { };
-
-        public void AddListener(Action<T, U, V, W> callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
-
-        public void AddOnce(Action<T, U, V, W> callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
-
-        public void RemoveListener(Action<T, U, V, W> callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            List<Type> retv = new List<Type>();
-            retv.Add(typeof(T));
-            retv.Add(typeof(U));
-            retv.Add(typeof(V));
-            retv.Add(typeof(W));
-            return retv;
-        }
-        public void Dispatch(T type1, U type2, V type3, W type4)
-        {
-            Listener(type1, type2, type3, type4);
-            OnceListener(type1, type2, type3, type4);
-            OnceListener = delegate { };
-            object[] outv = { type1, type2, type3, type4 };
-            base.Dispatch(outv);
-        }
-
-        private Action<T, U, V, W> AddUnique(Action<T, U, V, W> listeners, Action<T, U, V, W> callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
-    }
+	/// Base concrete form for a Signal with four parameters
+	public class Signal<T, U, V, W> : BaseSignal {
+		public event Action<T, U, V, W> Listener = delegate { };
+		public event Action<T, U, V, W> OnceListener = delegate { };
+		public void AddListener(Action<T, U, V, W> callback) { Listener += callback; }
+		public void AddOnce(Action<T, U, V, W> callback) { OnceListener += callback; }
+		public void RemoveListener(Action<T, U, V, W> callback) { Listener -= callback; }
+		public override void RemoveAllListeners() { Listener = delegate { }; }
+		public override List<Type> GetTypes() {
+			List<Type> retv = new List<Type>();
+			retv.Add(typeof(T));
+			retv.Add(typeof(U));
+			retv.Add(typeof(V));
+			retv.Add(typeof(W));
+			return retv;
+		}
+		public void Dispatch(T type1, U type2, V type3, W type4) {
+			Listener(type1, type2, type3, type4);
+			OnceListener(type1, type2, type3, type4);
+			OnceListener = delegate { };
+			object[] outv = { type1, type2, type3, type4 };
+			base.Dispatch(outv);
+		}
+	}
 
 }

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
@@ -43,7 +43,9 @@
 		signalWithNoParameters.Dispatch();
 		//Remove the listener
 		signalWithNoParameters.RemoveListener(callbackWithNoParameters);
-
+		//Remove all listeners
+		signalWithNoParameters.RemoveAllListeners();
+		
 		//SIGNAL WITH PARAMETERS
 		//Create a new signal with two parameters
 		Signal<int, string> signal = new Signal<int, string>();
@@ -59,6 +61,8 @@
 		signal.Dispatch(42, "zaphod");
 		//Remove the first listener. The listener added by AddOnce has been automatically removed.
 		signal.RemoveListener(callbackWithParamsIntAndString);
+		//Remove all listeners
+		signal.RemoveAllListeners();
  * 
  * @see strange.extensions.signal.api.IBaseSignal
  * @see strange.extensions.signal.impl.BasrSignal
@@ -66,105 +70,199 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
-namespace strange.extensions.signal.impl {
+namespace strange.extensions.signal.impl
+{
 	/// Base concrete form for a Signal with no parameters
-	public class Signal : BaseSignal {
+	public class Signal : BaseSignal
+	{
 		public event Action Listener = delegate { };
 		public event Action OnceListener = delegate { };
-		public void AddListener(Action callback) { Listener += callback; }
-		public void AddOnce(Action callback) { OnceListener += callback; }
+
+		public void AddListener(Action callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
+
+		public void AddOnce(Action callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
 		public void RemoveListener(Action callback) { Listener -= callback; }
 		public override void RemoveAllListeners() { Listener = delegate { }; }
-		public override List<Type> GetTypes() {
+		public override List<Type> GetTypes()
+		{
 			return new List<Type>();
 		}
-		public void Dispatch() {
+		public void Dispatch()
+		{
 			Listener();
 			OnceListener();
 			OnceListener = delegate { };
 			base.Dispatch(null);
 		}
+
+		private Action AddUnique(Action listeners, Action callback)
+		{
+			if (!listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
 	}
 
 	/// Base concrete form for a Signal with one parameter
-	public class Signal<T> : BaseSignal {
+	public class Signal<T> : BaseSignal
+	{
 		public event Action<T> Listener = delegate { };
 		public event Action<T> OnceListener = delegate { };
-		public void AddListener(Action<T> callback) { Listener += callback; }
-		public void AddOnce(Action<T> callback) { OnceListener += callback; }
+
+		public void AddListener(Action<T> callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
+
+		public void AddOnce(Action<T> callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
+
 		public void RemoveListener(Action<T> callback) { Listener -= callback; }
 		public override void RemoveAllListeners() { Listener = delegate { }; }
-		public override List<Type> GetTypes() {
+		public override List<Type> GetTypes()
+		{
 			List<Type> retv = new List<Type>();
 			retv.Add(typeof(T));
 			return retv;
 		}
-		public void Dispatch(T type1) {
+		public void Dispatch(T type1)
+		{
 			Listener(type1);
 			OnceListener(type1);
 			OnceListener = delegate { };
 			object[] outv = { type1 };
 			base.Dispatch(outv);
 		}
+
+		private Action<T> AddUnique(Action<T> listeners, Action<T> callback)
+		{
+			if (!listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
 	}
 
 	/// Base concrete form for a Signal with two parameters
-	public class Signal<T, U> : BaseSignal {
+	public class Signal<T, U> : BaseSignal
+	{
 		public event Action<T, U> Listener = delegate { };
 		public event Action<T, U> OnceListener = delegate { };
-		public void AddListener(Action<T, U> callback) { Listener += callback; }
-		public void AddOnce(Action<T, U> callback) { OnceListener += callback; }
+
+		public void AddListener(Action<T, U> callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
+
+		public void AddOnce(Action<T, U> callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
+
 		public void RemoveListener(Action<T, U> callback) { Listener -= callback; }
 		public override void RemoveAllListeners() { Listener = delegate { }; }
-		public override List<Type> GetTypes() {
+		public override List<Type> GetTypes()
+		{
 			List<Type> retv = new List<Type>();
 			retv.Add(typeof(T));
 			retv.Add(typeof(U));
 			return retv;
 		}
-		public void Dispatch(T type1, U type2) {
+		public void Dispatch(T type1, U type2)
+		{
 			Listener(type1, type2);
 			OnceListener(type1, type2);
 			OnceListener = delegate { };
 			object[] outv = { type1, type2 };
 			base.Dispatch(outv);
 		}
+		private Action<T, U> AddUnique(Action<T, U> listeners, Action<T, U> callback)
+		{
+			if (!listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
 	}
 
 	/// Base concrete form for a Signal with three parameters
-	public class Signal<T, U, V> : BaseSignal {
+	public class Signal<T, U, V> : BaseSignal
+	{
 		public event Action<T, U, V> Listener = delegate { };
 		public event Action<T, U, V> OnceListener = delegate { };
-		public void AddListener(Action<T, U, V> callback) { Listener += callback; }
-		public void AddOnce(Action<T, U, V> callback) { OnceListener += callback; }
+
+		public void AddListener(Action<T, U, V> callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
+
+		public void AddOnce(Action<T, U, V> callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
+
 		public void RemoveListener(Action<T, U, V> callback) { Listener -= callback; }
 		public override void RemoveAllListeners() { Listener = delegate { }; }
-		public override List<Type> GetTypes() {
+		public override List<Type> GetTypes()
+		{
 			List<Type> retv = new List<Type>();
 			retv.Add(typeof(T));
 			retv.Add(typeof(U));
 			retv.Add(typeof(V));
 			return retv;
 		}
-		public void Dispatch(T type1, U type2, V type3) {
+		public void Dispatch(T type1, U type2, V type3)
+		{
 			Listener(type1, type2, type3);
 			OnceListener(type1, type2, type3);
 			OnceListener = delegate { };
 			object[] outv = { type1, type2, type3 };
 			base.Dispatch(outv);
 		}
+		private Action<T, U, V> AddUnique(Action<T, U, V> listeners, Action<T, U, V> callback)
+		{
+			if (!listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
 	}
 
 	/// Base concrete form for a Signal with four parameters
-	public class Signal<T, U, V, W> : BaseSignal {
+	public class Signal<T, U, V, W> : BaseSignal
+	{
 		public event Action<T, U, V, W> Listener = delegate { };
 		public event Action<T, U, V, W> OnceListener = delegate { };
-		public void AddListener(Action<T, U, V, W> callback) { Listener += callback; }
-		public void AddOnce(Action<T, U, V, W> callback) { OnceListener += callback; }
+
+		public void AddListener(Action<T, U, V, W> callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
+
+		public void AddOnce(Action<T, U, V, W> callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
+
 		public void RemoveListener(Action<T, U, V, W> callback) { Listener -= callback; }
 		public override void RemoveAllListeners() { Listener = delegate { }; }
-		public override List<Type> GetTypes() {
+		public override List<Type> GetTypes()
+		{
 			List<Type> retv = new List<Type>();
 			retv.Add(typeof(T));
 			retv.Add(typeof(U));
@@ -172,12 +270,22 @@ namespace strange.extensions.signal.impl {
 			retv.Add(typeof(W));
 			return retv;
 		}
-		public void Dispatch(T type1, U type2, V type3, W type4) {
+		public void Dispatch(T type1, U type2, V type3, W type4)
+		{
 			Listener(type1, type2, type3, type4);
 			OnceListener(type1, type2, type3, type4);
 			OnceListener = delegate { };
 			object[] outv = { type1, type2, type3, type4 };
 			base.Dispatch(outv);
+		}
+
+		private Action<T, U, V, W> AddUnique(Action<T, U, V, W> listeners, Action<T, U, V, W> callback)
+		{
+			if (!listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
 		}
 	}
 


### PR DESCRIPTION
Added new RemoveAllListeners method to the Signal classes. Calling this method will effectively reset the Listener delegate reference, removing all listeners in the process.