### PR TITLE
allow interfaces to be bound to other interfaces provided those bindings...

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
@@ -80,7 +80,7 @@ namespace strange.extensions.injector.impl
 
 		override public IBinding GetRawBinding()
 		{
-			return new InjectionBinding (resolver);
+			return new InjectionBinding (this, resolver);
 		}
 
 		public IInjector injector

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinding.cs
@@ -168,20 +168,47 @@ namespace strange.extensions.injector.impl
 			return base.Bind (key) as IInjectionBinding;
 		}
 
-		new public IInjectionBinding To<T>()
-		{
-		    if (typeof (T).IsInterface)
-		    {
-		        return _injectionBinder.GetBinding<T>();
-		    }
+        new public IInjectionBinding To<T>()
+        {
+            if (typeof(T).IsInterface)
+            {
+                return To(typeof(T));
+            }
 
-			return base.To<T> () as IInjectionBinding;
-		}
+            return base.To<T>() as IInjectionBinding;
+        }
 
-		new public IInjectionBinding To(object o)
-		{
-			return base.To (o) as IInjectionBinding;
-		}
+        new public IInjectionBinding To(object o)
+        {
+            Type toType = o as Type;
+            if (toType != null && toType.IsInterface)
+            {
+                var existingBinding = _injectionBinder.GetBinding(toType);
+                if (existingBinding == null)
+                {
+                    throw new InjectionException("Attempted to bind to an interface which does not have a previously defined binding.", InjectionExceptionType.NOT_INSTANTIABLE);
+                }
+                Type existingValue = existingBinding.value as Type;
+                if (existingValue != null)
+                {
+                    if (existingValue.IsInterface)
+                    {
+                        return To(existingValue);
+                    }
+
+                    // Found concrete value type, so use the key to get an instance
+                    object[] existingBindingKey = existingBinding.key as object[];
+                    Type keyType = existingBindingKey[0] as Type;
+
+                    return ToValue(_injectionBinder.GetInstance(keyType));
+                }
+
+                // Will this even happen? Existing value was a non-type object
+                return base.To(existingBinding.value) as IInjectionBinding;
+            }
+
+            return base.To(o) as IInjectionBinding;
+        }
 
 		new public IInjectionBinding ToName<T>()
 		{

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinding.cs
@@ -32,11 +32,13 @@ namespace strange.extensions.injector.impl
 	public class InjectionBinding : Binding, IInjectionBinding
 	{
 		private InjectionBindingType _type = InjectionBindingType.DEFAULT;
+	    private IInjectionBinder _injectionBinder;
 		private bool _toInject = true;
 		private bool _isCrossContext = false;
 
-		public InjectionBinding (Binder.BindingResolver resolver)
+		public InjectionBinding (IInjectionBinder injectionBinder, Binder.BindingResolver resolver)
 		{
+		    _injectionBinder = injectionBinder;
 			this.resolver = resolver;
 			keyConstraint = BindingConstraintType.MANY;
 			valueConstraint = BindingConstraintType.ONE;
@@ -168,6 +170,11 @@ namespace strange.extensions.injector.impl
 
 		new public IInjectionBinding To<T>()
 		{
+		    if (typeof (T).IsInterface)
+		    {
+		        return _injectionBinder.GetBinding<T>();
+		    }
+
 			return base.To<T> () as IInjectionBinding;
 		}
 


### PR DESCRIPTION
Consider this pull request.  Allows interfaces to be bound to other interfaces provided those bindings already exist. 

Example:

injectionBinder.Bind&lt;ISpeakingCat&gt;.To&lt;Cat&gt;().ToSingleton();
injectionBinder.Bind&lt;ICat&gt;.To&lt;ISpeakingCat&gt;().ToSingleton();
injectionBinder.Bind&lt;ISpeaking&gt;.To&lt;ISpeakingCat&gt;().ToSingleton();

This allows to have a Cat as a singleton, and get access to the ISpeaking methods and ICat methods seperately without making ICat directly implement ISpeaking.

This becomes more useful when combined with list injection, which I hope will be merged soon,
Then you can ask for a list of ISpeaking somewhere else and do your ISpeaking tasks, without any users of ICat having access to those methods.


Real world example where I am using this now, I have an interface called IUpdate which calls Update() method on certain non-monobehavior classes on every tick. But, the update is called from a central location.  I don't want users of the class to be able to call Update manually. They would not be able to because the class is implemented like this:

public class ManagerClass : IManagerInternal 
{
}

internal interface IManagerInternal : IManager, IUpdate
{
}

public interface IManager
{
// manager only methods
}

public interface IUpdate
{
void Update();
}


hope that makes sense and you will agree this is a useful thing to have