### PR TITLE
Implemented a list binder.

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/listBind/TestListBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/listBind/TestListBinder.cs
@@ -1,0 +1,243 @@
+﻿using NUnit.Framework;
+using strange.extensions.context.impl;
+using strange.extensions.injector.api;
+using strange.extensions.injector.impl;
+using strange.extensions.listBind.api;
+using strange.extensions.listBind.impl;
+using System.Collections.Generic;
+
+namespace strange.unittests
+{
+    [TestFixture]
+    public class TestListBinder
+    {
+        private MockContext context;
+        private IListBinder binder;
+        private IInjectionBinder injectionBinder;
+        private object contextView;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Context.firstContext = null;
+            contextView = new object();
+            context = new MockContext(contextView, true);
+            context.Start();
+            binder = context.listBinder;
+            injectionBinder = context.injectionBinder;
+
+            injectionBinder.Bind<ListItemDependency>().To<ListItemDependency>();
+        }
+
+        [Test]
+        public void TestBindToListButNotToInjectionBinder()
+        {
+            binder.Bind<IListItem>().To<ListItemA>();
+            var list = context.injectionBinder.GetInstance<IList<IListItem>>();
+            var listInstance = list[0];
+            IListItem instance = null;
+            bool exception = false;
+            try
+            {
+                instance = context.injectionBinder.GetInstance<IListItem>();
+            } catch(InjectionException e)
+            {
+                exception = true;
+            }
+            Assert.True(exception);
+            Assert.NotNull(listInstance);
+            Assert.Null(instance);
+        }
+
+        [Test]
+        public void TestBindDuplicateType()
+        {
+            binder.Bind<IListItem>().To<ListItemA>();
+            binder.Bind<IListItem>().To<ListItemA>();
+            var list = context.injectionBinder.GetInstance<IList<IListItem>>();
+            Assert.AreEqual(2, list.Count);
+            Assert.IsAssignableFrom(typeof(ListItemA), list[0]);
+            Assert.IsAssignableFrom(typeof(ListItemA), list[1]);
+        }
+
+
+
+        [Test]
+        public void TestInjectListWithValues()
+        {
+            binder.Bind<string>().ToValue("a");
+            binder.Bind<string>().ToValue("b");
+            binder.Bind<string>().ToValue("c");
+
+            var strings = context.injectionBinder.GetInstance<IList<string>>();
+
+            Assert.AreEqual(3, strings.Count);
+            Assert.AreEqual("a", strings[0]);
+            Assert.AreEqual("b", strings[1]);
+            Assert.AreEqual("c", strings[2]);
+        }
+
+        [Test]
+        public void TestInjectListWithDuplicateValues()
+        {
+            binder.Bind<string>().ToValue("a");
+            binder.Bind<string>().ToValue("b");
+            binder.Bind<string>().ToValue("a");
+
+            var strings = context.injectionBinder.GetInstance<IList<string>>();
+
+            Assert.AreEqual(3, strings.Count);
+            Assert.AreEqual(strings[0], strings[2]);
+        }
+
+
+        [Test]
+        public void TestInjectTypesWithDependenciesToList()
+        {
+            binder.Bind<IListItem>().To<ListItemA>();
+            binder.Bind<IListItem>().To<ListItemB>();
+
+            var list = context.injectionBinder.GetInstance<IList<IListItem>>();
+
+            Assert.AreEqual(2, list.Count);
+            Assert.IsAssignableFrom(typeof(ListItemA), list[0]);
+            Assert.NotNull(list[0].Dep);
+            Assert.IsAssignableFrom(typeof(ListItemB), list[1]);
+            Assert.NotNull(list[1].Dep);
+        }
+
+
+        [Test]
+        public void TestInjectListWithSingletonItems()
+        {
+            
+            binder.Bind<IListItem>().To<ListItemA>().ToSingleton();
+            binder.Bind<IListItem>().To<ListItemB>();
+
+            var list1 = context.injectionBinder.GetInstance<IList<IListItem>>();
+            var list2 = context.injectionBinder.GetInstance<IList<IListItem>>();
+
+            Assert.AreNotEqual(list1, list2);
+
+            // Singleton
+            Assert.AreEqual(list1[0], list2[0]);
+
+            // New instance
+            Assert.AreNotEqual(list1[1], list2[1]);
+            
+        }
+
+        [Test]
+        public void TestInjectListWithMixedValuesAndTypes()
+        {
+            binder.Bind<IListItem>().ToValue(new ListItemA(new ListItemDependency()));
+            binder.Bind<IListItem>().To<ListItemB>();
+
+            var list1 = context.injectionBinder.GetInstance<IList<IListItem>>();
+            var list2 = context.injectionBinder.GetInstance<IList<IListItem>>();
+
+            Assert.AreNotEqual(list1, list2);
+
+            // Bound by value
+            Assert.AreEqual(list1[0], list2[0]);
+
+            // New instance
+            Assert.AreNotEqual(list1[1], list2[1]);
+
+        }
+
+
+        [TestCase]
+        public void TestInjectListAsSingleton()
+        {
+            
+            binder.Bind<IListItem>().ToSingleton();
+            binder.Bind<IListItem>().ToValue(new ListItemA(new ListItemDependency()));
+            binder.Bind<IListItem>().To<ListItemB>();
+
+            var list1 = context.injectionBinder.GetInstance<IList<IListItem>>();
+            var list2 = context.injectionBinder.GetInstance<IList<IListItem>>();
+
+            // No matter how list items were bound they are all equal between 
+            // list1 and list2 because the list itself is bound as a singleton
+            Assert.AreEqual(list1, list2);
+            Assert.AreEqual(list1[0], list2[0]);
+            Assert.AreEqual(list1[1], list2[1]);
+            
+        }
+
+        [Test]
+        public void TestInjectSingletonToListAndStandalone()
+        {
+            binder.Bind<IListItem>().To<ListItemA>();
+            binder.Bind<IListItem>().To<ListItemB>();
+            binder.Bind<IListItem>().To<ListItemC>();
+
+            injectionBinder.Bind<ListItemB>().To<ListItemB>().ToSingleton();
+            injectionBinder.Bind<IListItem>().To<ListItemA>().ToSingleton();
+   
+            var list = context.injectionBinder.GetInstance<IList<IListItem>>();
+            var instanceA = context.injectionBinder.GetInstance<IListItem>();
+            var instanceB = context.injectionBinder.GetInstance<ListItemB>();
+
+            // The instace was bound as a singleton so list will contain that singleton 
+            Assert.AreEqual(list[0], instanceA);
+            Assert.AreEqual(list[1], instanceB);
+            Assert.IsAssignableFrom(typeof(ListItemC), list[2]);
+            
+
+        }
+    }
+
+
+
+    public interface IListItem
+    {
+        ListItemDependency Dep { get; }
+    }
+
+
+    public class ListItemA : IListItem
+    {
+        private readonly ListItemDependency dep;
+        public ListItemDependency Dep { get { return this.dep; } }
+        [Construct]
+        public ListItemA(ListItemDependency dep)
+        {
+            this.dep = dep;
+        }
+
+    }
+    public class ListItemB: IListItem
+    {
+        [Inject]
+        public ListItemDependency Dep { get; set; }
+
+    }
+
+    public class ListItemC : IListItem
+    {
+        [Inject]
+        public ListItemDependency Dep { get; set; }
+    }
+
+    public class ListItemWithInvalidConstructor : IListItem
+    {
+        private readonly ListItemDependency dep;
+        public ListItemDependency Dep { get { return this.dep; } }
+        public ListItemWithInvalidConstructor(ListItemDependency dep)
+        {
+            this.dep = dep;
+        }
+        public ListItemWithInvalidConstructor(ListItemDependency dep, string hops)
+        {
+            this.dep = dep;
+        }
+    }
+
+
+    public class ListItemDependency
+    {
+
+    }
+}

--- a/StrangeIoC/scripts/strange/.tests/testPayloads/MockContext.cs
+++ b/StrangeIoC/scripts/strange/.tests/testPayloads/MockContext.cs
@@ -12,6 +12,8 @@ using strange.extensions.dispatcher.eventdispatcher.impl;
 using strange.extensions.mediation.impl;
 using strange.extensions.sequencer.impl;
 using strange.extensions.dispatcher.api;
+using strange.extensions.listBind.api;
+using strange.extensions.listBind.impl;
 
 namespace strange.unittests
 {
@@ -30,7 +32,7 @@ namespace strange.unittests
 
 		/// A Binder that maps Events to Sequences
 		public ISequencer sequencer{get;set;}
-
+        public IListBinder listBinder { get; set; }
 		public IImplicitBinder implicitBinder { get; set; }
 
 		public MockContext() : base() {}
@@ -56,6 +58,7 @@ namespace strange.unittests
 			injectionBinder.Bind<IMediationBinder>().To<MediationBinder>().ToSingleton();
 			injectionBinder.Bind<ISequencer>().To<EventSequencer>().ToSingleton();
 			injectionBinder.Bind<IImplicitBinder>().To<ImplicitBinder>().ToSingleton();
+            injectionBinder.Bind<IListBinder>().To<ListBinder>().ToSingleton();
 		}
 
 		protected override void instantiateCoreComponents()
@@ -66,6 +69,7 @@ namespace strange.unittests
 			dispatcher = injectionBinder.GetInstance<IEventDispatcher>(ContextKeys.CONTEXT_DISPATCHER) as IEventDispatcher;
 			mediationBinder = injectionBinder.GetInstance<IMediationBinder>() as IMediationBinder;
 			sequencer = injectionBinder.GetInstance<ISequencer>() as ISequencer;
+            listBinder = injectionBinder.GetInstance<IListBinder>() as IListBinder;
 			implicitBinder = injectionBinder.GetInstance<IImplicitBinder>() as IImplicitBinder;
 
 			(dispatcher as ITriggerProvider).AddTriggerable(commandBinder as ITriggerable);

--- a/StrangeIoC/scripts/strange/extensions/context/impl/MVCSContext.cs
+++ b/StrangeIoC/scripts/strange/extensions/context/impl/MVCSContext.cs
@@ -171,6 +171,8 @@ using strange.extensions.sequencer.api;
 using strange.extensions.sequencer.impl;
 using strange.framework.api;
 using strange.framework.impl;
+using strange.extensions.listBind.api;
+using strange.extensions.listBind.impl;
 
 namespace strange.extensions.context.impl
 {
@@ -187,6 +189,9 @@ namespace strange.extensions.context.impl
 
 		//Interprets implicit bindings
 		public IImplicitBinder implicitBinder { get; set; }
+
+        /// A Binder that allows binding similar bindings to an injectable list.
+        public IListBinder listBinder { get; set; }
 
 		/// A Binder that maps Events to Sequences
 		public ISequencer sequencer{get;set;}
@@ -239,6 +244,7 @@ namespace strange.extensions.context.impl
 			injectionBinder.Bind<IMediationBinder>().To<MediationBinder>().ToSingleton();
 			injectionBinder.Bind<ISequencer>().To<EventSequencer>().ToSingleton();
 			injectionBinder.Bind<IImplicitBinder>().To<ImplicitBinder>().ToSingleton();
+            injectionBinder.Bind<IListBinder>().To<ListBinder>().ToSingleton();
 		}
 		
 		protected override void instantiateCoreComponents()
@@ -255,6 +261,7 @@ namespace strange.extensions.context.impl
 			mediationBinder = injectionBinder.GetInstance<IMediationBinder>() as IMediationBinder;
 			sequencer = injectionBinder.GetInstance<ISequencer>() as ISequencer;
 			implicitBinder = injectionBinder.GetInstance<IImplicitBinder>() as IImplicitBinder;
+            listBinder = injectionBinder.GetInstance<IListBinder>() as IListBinder;
 
 			(dispatcher as ITriggerProvider).AddTriggerable(commandBinder as ITriggerable);
 			(dispatcher as ITriggerProvider).AddTriggerable(sequencer as ITriggerable);

--- a/StrangeIoC/scripts/strange/extensions/injector/api/IInjector.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/api/IInjector.cs
@@ -42,6 +42,7 @@ using System;
 using System.Collections.Generic;
 using strange.extensions.reflector.api;
 using strange.framework.api;
+using strange.extensions.listBind.api;
 
 namespace strange.extensions.injector.api
 {
@@ -67,7 +68,8 @@ namespace strange.extensions.injector.api
 
 		/// Get/set an InjectionBinder.
 		IInjectionBinder binder{ get; set;}
-
+        /// Get/set an ListBinder.
+        IListBinder listBinder { get; set; }
 		/// Get/set a ReflectionBinder.
 		IReflectionBinder reflector{ get; set;}
 	}

--- a/StrangeIoC/scripts/strange/extensions/listBind/api/IListBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/listBind/api/IListBinder.cs
@@ -1,0 +1,28 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+
+using strange.framework.api;
+using System;
+
+namespace strange.extensions.listBind.api
+{
+    public interface IListBinder : IBinder
+    {
+        new IListBinding Bind<T>();
+        IListBinding GetListBinding(Type type);
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/listBind/api/IListBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/listBind/api/IListBinding.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+
+using strange.extensions.injector.api;
+using strange.framework.api;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace strange.extensions.listBind.api
+{
+    public interface IListBinding : IBinding
+    {
+        new IListItemBinding To<T>();
+        IListItemBinding ToValue(object o);
+
+        IListBinding ToSingleton();
+
+        Type ListType { get; set; }
+
+        List<IListItemBinding> Bindings { get; }
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/listBind/api/IListItemBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/listBind/api/IListItemBinding.cs
@@ -1,0 +1,15 @@
+﻿using strange.extensions.injector.api;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace strange.extensions.listBind.api
+{
+    public interface IListItemBinding
+    {
+        object Resolve(IInjectionBinder injectionBinder);
+
+        void ToSingleton();
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/listBind/impl/ListBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/listBind/impl/ListBinder.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+using strange.extensions.injector.api;
+using strange.extensions.listBind.api;
+using strange.framework.api;
+using strange.framework.impl;
+using System;
+using System.Collections.Generic;
+
+namespace strange.extensions.listBind.impl
+{
+    public class ListBinder : Binder, IListBinder
+    {
+        private readonly Dictionary<Type, IListBinding> listTypes = new Dictionary<Type, IListBinding>();
+        private IInjectionBinder _injectionBinder;
+
+        [Inject]
+        public IInjectionBinder injectionBinder 
+        {
+            get
+            {
+                return this._injectionBinder;
+            }
+            set
+            {
+                this._injectionBinder = value;
+                _injectionBinder.injector.listBinder = this;
+            }
+        }
+
+
+        public IListBinding GetListBinding(Type type)
+        {
+            if (!listTypes.ContainsKey(type))
+            {
+                return null;
+            }
+            return listTypes[type];
+        }
+
+        public override IBinding GetRawBinding()
+        {
+            return new ListBinding(resolver, _injectionBinder) as IBinding;
+        }
+
+        public new IListBinding Bind<T>()
+        {
+            IListBinding binding = null;
+            if (listTypes.ContainsKey(typeof(T)))
+            {
+                binding = listTypes[typeof(T)];   
+            }
+            else
+            {
+                binding = base.Bind<T>() as IListBinding;
+                binding.ListType = typeof(IList<T>);
+                listTypes[typeof(T)] = binding;
+                injectionBinder.Bind<IList<T>>().To<List<T>>();
+            }
+            return binding;
+        }
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/listBind/impl/ListBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/listBind/impl/ListBinding.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+using strange.extensions.injector.api;
+using strange.extensions.listBind.api;
+using strange.framework.api;
+using strange.framework.impl;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using strange.extensions.injector.impl;
+
+namespace strange.extensions.listBind.impl
+{
+    public class ListBinding : Binding, IListBinding
+    {
+        private readonly List<IListItemBinding> bindings = new List<IListItemBinding>();
+
+        private readonly IInjectionBinder injectionBinder;
+
+        public ListBinding(Binder.BindingResolver resolver, IInjectionBinder injectionBinder)
+            : base(resolver)
+		{
+            this.injectionBinder = injectionBinder;
+		}
+
+        public List<IListItemBinding> Bindings { get { return this.bindings; } }
+        public Type ListType { get; set; }
+
+        public Type ListItemType 
+        {
+            get
+            {
+                return ListType.GetGenericArguments()[0];
+            }
+        }
+
+        public new IListItemBinding To<T>()
+        {
+            var injectionBinding = injectionBinder.GetBinding<T>();
+            if (injectionBinding == null)
+            {
+                injectionBinding = new InjectionBinding(resolver);
+                injectionBinding.Bind(typeof(T));
+            }
+        
+            ToTypeBinding toType = new ToTypeBinding(injectionBinding, ListItemType, typeof(T));
+            this.bindings.Add(toType);
+            return toType;
+
+        }
+
+        public IListItemBinding ToValue(object o)
+        {
+            ToValueBinding toValue = new ToValueBinding(o);
+            this.bindings.Add(toValue);
+            return toValue;
+        }
+
+
+        
+        public IListBinding ToSingleton()
+        {
+            var listBinding = injectionBinder.GetBinding(ListType);
+            listBinding.ToSingleton();
+            return this;
+        }
+         
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/listBind/impl/ToTypeBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/listBind/impl/ToTypeBinding.cs
@@ -1,0 +1,86 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+using strange.extensions.injector.api;
+using strange.extensions.injector.impl;
+using strange.extensions.listBind.api;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace strange.extensions.listBind.impl
+{
+    public class ToTypeBinding : IListItemBinding
+    {
+        private readonly Type fromType;
+        private readonly Type type;
+        private bool asSingleton;
+        private object instance;
+
+        private IInjectionBinding injectionBinding;
+
+        public ToTypeBinding(IInjectionBinding injectionBinding, Type fromType, Type type)
+        {
+            this.fromType = fromType;
+            this.type = type;
+            this.injectionBinding = injectionBinding;
+            asSingleton = false;
+        }
+
+        public object Resolve(IInjectionBinder injectionBinder)
+        {
+            // First give a chance for the "officially" bound bindings to find the instances
+            var bindingType = this.type;
+            IInjectionBinding binding = injectionBinder.GetBinding(bindingType);
+            if (binding == null)
+            {
+                binding = injectionBinder.GetBinding(this.fromType);
+                bindingType = this.fromType;
+            }
+            if (binding != null)
+            {
+                var bound = injectionBinder.GetInstance(bindingType, null);
+                if (bound.GetType().Equals(type))
+                {
+                    return bound;
+                }
+            }
+
+            // Then, let's see if we have a singleton
+            if (asSingleton && this.instance != null)
+            {
+                return this.instance;
+            }
+            
+            // Then we'll use the temporary binding to create the instance.
+            var instance = injectionBinder.injector.Instantiate(this.injectionBinding);
+            if (asSingleton)
+            {
+                this.instance = instance;
+            }
+            return instance;
+            
+        }
+
+        public void ToSingleton()
+        {
+            asSingleton = true;
+        }
+
+    }
+}

--- a/StrangeIoC/scripts/strange/extensions/listBind/impl/ToValueBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/listBind/impl/ToValueBinding.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+using strange.extensions.listBind.api;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace strange.extensions.listBind.impl
+{
+    public class ToValueBinding : IListItemBinding
+    {
+        private readonly object value;
+
+        public ToValueBinding(object value)
+        {
+            this.value = value;
+        }
+
+        public object Resolve(injector.api.IInjectionBinder injectionBinder)
+        {
+            return this.value;
+        }
+
+
+        public void ToSingleton()
+        {
+            // To Value is by nature bound as a singleton
+        }
+    }
+}


### PR DESCRIPTION
List binder can be used to bind multiple instances of the same interface (T) to an IList<T>. Injector will populate any injected and bound lists trying to populate the list as follows:
1. Check the injectionBinder for existing binding and use it when instantiating a list item
2. Create a temporary binding, not registering it to the injection binder, and use the temporary binding to instantiate a list item

Also, values can be directly bound to list.

See TestListBinder.cs for reference