### PR TITLE
Made Command class abstract

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/testPayloads/Commands/CommandWithoutExecute.cs
+++ b/StrangeIoC/scripts/strange/.tests/testPayloads/Commands/CommandWithoutExecute.cs
@@ -1,4 +1,4 @@
-using System;
+using strange.extensions.command.api;
 using strange.extensions.command.impl;
 
 namespace strange.unittests
@@ -8,6 +8,10 @@ namespace strange.unittests
 		public CommandWithoutExecute ()
 		{
 		}
+
+		public override void Execute()
+		{
+			throw new CommandException("You must override the Execute method in every Command", CommandExceptionType.EXECUTE_OVERRIDE);
+		}
 	}
 }
-

--- a/StrangeIoC/scripts/strange/.tests/testPayloads/SequenceCommands/SequenceCommandWithExecute.cs
+++ b/StrangeIoC/scripts/strange/.tests/testPayloads/SequenceCommands/SequenceCommandWithExecute.cs
@@ -1,16 +1,18 @@
-using System;
+using strange.extensions.command.api;
+using strange.extensions.command.impl;
 using strange.extensions.sequencer.impl;
 
 namespace strange.unittests
 {
-	public class SequenceCommandWithExecute : SequenceCommand
+	public class SequenceCommandWithoutExecute : SequenceCommand
 	{
-		public override void Execute ()
+		public SequenceCommandWithoutExecute ()
 		{
-			if (true)
-			{
+		}
 
-			}
+		public override void Execute()
+		{
+			throw new CommandException("You must override the Execute method in every Command", CommandExceptionType.EXECUTE_OVERRIDE);
 		}
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/command/impl/Command.cs
+++ b/StrangeIoC/scripts/strange/extensions/command/impl/Command.cs
@@ -33,15 +33,13 @@
  * has no effect on Commands operating in parallel.
  */
 
-using System;
 using strange.extensions.command.api;
 using strange.extensions.injector.api;
-using strange.framework.api;
 using strange.extensions.pool.api;
 
 namespace strange.extensions.command.impl
 {
-	public class Command : ICommand, IPoolable
+	public abstract class Command : ICommand, IPoolable
 	{
 		/// Back reference to the CommandBinder that instantiated this Commmand
 		[Inject]
@@ -67,10 +65,7 @@ namespace strange.extensions.command.impl
 			IsClean = false;
 		}
 
-		virtual public void Execute()
-		{
-			throw new CommandException ("You must override the Execute method in every Command", CommandExceptionType.EXECUTE_OVERRIDE);
-		}
+		public abstract void Execute();
 
 		public virtual void Retain()
 		{

--- a/StrangeIoC/scripts/strange/extensions/command/impl/EventCommand.cs
+++ b/StrangeIoC/scripts/strange/extensions/command/impl/EventCommand.cs
@@ -23,15 +23,12 @@
  * Commands which extend Event Command will automatically inject the source IEvent.
  */
 
-using System;
 using strange.extensions.context.api;
 using strange.extensions.dispatcher.eventdispatcher.api;
-using strange.extensions.command.impl;
-using strange.extensions.pool.api;
 
 namespace strange.extensions.command.impl
 {
-	public class EventCommand : Command
+	public abstract class EventCommand : Command
 	{
 		[Inject(ContextKeys.CONTEXT_DISPATCHER)]
 		public IEventDispatcher dispatcher{ get; set;}

--- a/StrangeIoC/scripts/strange/extensions/dispatcher/eventdispatcher/impl/EventDispatcher.cs
+++ b/StrangeIoC/scripts/strange/extensions/dispatcher/eventdispatcher/impl/EventDispatcher.cs
@@ -103,7 +103,7 @@ namespace strange.extensions.dispatcher.eventdispatcher.impl
 							break;
 						}
 					}
-					catch (Exception ex) //If trigger throws, we still want to cleanup!
+					catch (Exception) //If trigger throws, we still want to cleanup!
 					{
 						internalReleaseEvent(evt);
 						throw;

--- a/StrangeIoC/scripts/strange/extensions/sequencer/impl/EventSequenceCommand.cs
+++ b/StrangeIoC/scripts/strange/extensions/sequencer/impl/EventSequenceCommand.cs
@@ -23,11 +23,10 @@
 using System;
 using strange.extensions.context.api;
 using strange.extensions.dispatcher.eventdispatcher.api;
-using strange.extensions.sequencer.impl;
 
 namespace strange.extensions.sequencer.impl
 {
-	public class EventSequenceCommand : SequenceCommand
+	public abstract class EventSequenceCommand : SequenceCommand
 	{
 		/// The context-wide Event bus
 		[Inject(ContextKeys.CONTEXT_DISPATCHER)]

--- a/StrangeIoC/scripts/strange/extensions/sequencer/impl/SequenceCommand.cs
+++ b/StrangeIoC/scripts/strange/extensions/sequencer/impl/SequenceCommand.cs
@@ -22,14 +22,12 @@
  * @see strange.extensions.command.api.ICommand
  */ 
 
-using System;
 using strange.extensions.command.impl;
-using strange.extensions.injector.api;
 using strange.extensions.sequencer.api;
 
 namespace strange.extensions.sequencer.impl
 {
-	public class SequenceCommand : Command, ISequenceCommand
+	public abstract class SequenceCommand : Command, ISequenceCommand
 	{
 		[Inject]
 		public ISequencer sequencer{ get; set;}
@@ -44,11 +42,6 @@ namespace strange.extensions.sequencer.impl
 			{
 				sequencer.Stop (this);
 			}
-		}
-
-		new virtual public void Execute ()
-		{
-			throw new SequencerException ("You must override the Execute method in every SequenceCommand", SequencerExceptionType.EXECUTE_OVERRIDE);
 		}
 
 		new public void Release ()


### PR DESCRIPTION
The Command class should be abstract and so should it's Execute method. Currently this method throws a run time exception if not overridden, but it's better to get compile time errors if you're inheriting from Command and not implementing Execute.