### PR TITLE
Marc/abstract mediation

### DIFF
--- a/Assembly-CSharp-vs.csproj
+++ b/Assembly-CSharp-vs.csproj
@@ -354,5 +354,6 @@
     <Compile Include="StrangeIoC\scripts\strange\lib\MiniJSON.cs" />
     <Compile Include="StrangeIoC\scripts\strange\.tests\testPayloads\InjectsClassToBeInjected.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\MediationBinder.cs" />
+    <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\AbstractMediationBinder.cs" />
   </ItemGroup>
 </Project>

--- a/Assembly-CSharp-vs.csproj
+++ b/Assembly-CSharp-vs.csproj
@@ -41,8 +41,6 @@
       <HintPath>..\..\..\..\..\Applications\Unity\Unity.app\Contents\Frameworks\Managed\UnityEditor.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
-    <Reference Include="nunit.core, Version=2.6.0.12051, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77" />
-    <Reference Include="nunit.core.interfaces, Version=2.6.0.12051, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77" />
     <Reference Include="nunit.framework">
       <HintPath>packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/Assembly-CSharp-vs.csproj
+++ b/Assembly-CSharp-vs.csproj
@@ -79,6 +79,7 @@
     <Folder Include="StrangeIoC\examples\Assets\scripts\multiplecontexts\common\" />
     <Folder Include="StrangeIoC\examples\Assets\scripts\multiplecontexts\common\controller\" />
     <Folder Include="StrangeIoC\scripts\strange\lib\" />
+    <Folder Include="StrangeIoC\scripts\strange\.tests\extensions\mediation\" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
@@ -355,5 +356,6 @@
     <Compile Include="StrangeIoC\scripts\strange\.tests\testPayloads\InjectsClassToBeInjected.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\MediationBinder.cs" />
     <Compile Include="StrangeIoC\scripts\strange\extensions\mediation\impl\AbstractMediationBinder.cs" />
+    <Compile Include="StrangeIoC\scripts\strange\.tests\extensions\mediation\TestAbstractMediationBinder.cs" />
   </ItemGroup>
 </Project>

--- a/StrangeIoC/scripts/strange/.tests/extensions/mediation/TestAbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/mediation/TestAbstractMediationBinder.cs
@@ -106,7 +106,7 @@ namespace strange.unittests
 		public void TestInjectViews()
 		{
 			injectionBinder.Bind<ClassToBeInjected>().To<ClassToBeInjected>();
-			object mono = new object();
+
 			TestView view = new TestView();
 			IView one = new TestView();
 			IView two = new TestView();
@@ -166,6 +166,11 @@ namespace strange.unittests
 				mediator.OnRemove ();
 			}
 			return mediator;
+		}
+
+		protected override void ThrowNullMediatorError (Type viewType, Type mediatorType)
+		{
+			throw new MediationException("The view: " + viewType.ToString() + " is mapped to mediator: " + mediatorType.ToString() + ". AddComponent resulted in null, which probably means " + mediatorType.ToString().Substring(mediatorType.ToString().LastIndexOf(".") + 1) + " is not a MonoBehaviour.", MediationExceptionType.NULL_MEDIATOR);
 		}
 
 		public void TestInjectViewAndChildren(IView view)

--- a/StrangeIoC/scripts/strange/.tests/extensions/mediation/TestAbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/mediation/TestAbstractMediationBinder.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Diagnostics;
+using NUnit.Framework;
+using strange.framework.api;
+using strange.framework.impl;
+using strange.extensions.injector.api;
+using strange.extensions.injector.impl;
+using strange.extensions.mediation.impl;
+using strange.extensions.mediation.api;
+using System.Collections.Generic;
+
+
+namespace strange.unittests
+{
+	[TestFixture()]
+	public class TestAbstractMediationBinder
+	{
+		private TestMediationBinder mediationBinder;
+		private InjectionBinder injectionBinder;
+
+
+		[SetUp]
+		public void SetUp()
+		{
+			injectionBinder = new InjectionBinder ();
+			mediationBinder = new TestMediationBinder ();
+			mediationBinder.injectionBinder = injectionBinder;
+		}
+
+		[Test]
+		public void TestRawBindingIsMediationBinding()
+		{
+			IBinding binding = mediationBinder.GetRawBinding ();
+			Assert.IsInstanceOf<IMediationBinding> (binding);
+		}
+
+		[Test]
+		public void TestAwakeTriggersMappingAndInjection()
+		{
+			mediationBinder.Bind<TestView> ().To<TestMediator> ();
+			injectionBinder.Bind<ClassToBeInjected> ().To<ClassToBeInjected> ();
+
+			TestView view = new TestView ();
+			mediationBinder.Trigger (MediationEvent.AWAKE, view);
+
+			Assert.IsTrue (view.registeredWithContext);
+			Assert.IsNotNull (view.testInjection);
+			TestMediator mediator = mediationBinder.mediators [view] as TestMediator;
+			Assert.AreEqual (1, mediationBinder.mediators.Count);
+			Assert.IsNotNull (mediator);
+			Assert.IsInstanceOf<TestMediator> (mediator);
+
+			Assert.IsTrue (mediator.preregistered);
+			Assert.IsTrue (mediator.registered);
+			Assert.IsFalse (mediator.removed);
+		}
+
+		[Test]
+		public void TestAwakeTriggersInjectionForUnmappedView()
+		{
+			injectionBinder.Bind<ClassToBeInjected> ().To<ClassToBeInjected> ();
+
+			TestView view = new TestView ();
+			mediationBinder.Trigger (MediationEvent.AWAKE, view);
+
+			Assert.IsNotNull (view.testInjection);
+			TestMediator mediator = null;
+			if (mediationBinder.mediators.ContainsKey(view))
+			{
+				mediator = mediationBinder.mediators [view] as TestMediator;
+			}
+			Assert.AreEqual (0, mediationBinder.mediators.Count);
+			Assert.IsNull (mediator);
+		}
+
+		[Test]
+		public void TestDestroyedTriggersUnmapping()
+		{
+			mediationBinder.Bind<TestView> ().To<TestMediator> ();
+			injectionBinder.Bind<ClassToBeInjected> ().To<ClassToBeInjected> ();
+
+			TestView view = new TestView ();
+			mediationBinder.Trigger (MediationEvent.AWAKE, view);
+
+			TestMediator mediator = mediationBinder.mediators [view] as TestMediator;
+
+			mediationBinder.Trigger (MediationEvent.DESTROYED, view);
+			Assert.IsTrue (mediator.removed);
+			Assert.AreEqual (0, mediationBinder.mediators.Count);
+		}
+
+		[Test]
+		public void TestErrorIfClassMappedToItself()
+		{
+			mediationBinder.Bind<TestView> ().To<TestView> ();
+			injectionBinder.Bind<ClassToBeInjected> ().To<ClassToBeInjected> ();
+
+			TestView view = new TestView ();
+
+			TestDelegate testDelegate = delegate
+			{
+				mediationBinder.Trigger (MediationEvent.AWAKE, view);
+			};
+			MediationException ex = Assert.Throws<MediationException>(testDelegate); //Because we've mapped view to self
+			Assert.AreEqual (MediationExceptionType.MEDIATOR_VIEW_STACK_OVERFLOW, ex.type);
+		}
+	}
+
+
+	class TestMediationBinder : AbstractMediationBinder
+	{
+
+		public Dictionary<IView, IMediator> mediators = new Dictionary<IView, IMediator>();
+		
+		override protected void InjectViewAndChildren(IView view)
+		{
+			injectionBinder.injector.Inject (view);
+		}
+
+		override protected object CreateMediator(IView view, Type mediatorType)
+		{
+			IMediator mediator = new TestMediator ();
+			mediators.Add (view, mediator);
+			return mediator;
+		}
+
+		override protected object DestroyMediator(IView view, Type mediatorType)
+		{
+			IMediator mediator = null;
+			if (mediators.ContainsKey(view))
+			{
+				mediator = mediators[view];
+				mediators.Remove(view);
+				mediator.OnRemove ();
+			}
+			return mediator;
+		}
+
+		override protected void ApplyMediationToView(IMediationBinding binding, IView view, Type mediatorType)
+		{
+			IMediator mediator = CreateMediator (view, mediatorType) as IMediator;
+			mediator.PreRegister ();
+			injectionBinder.injector.Inject (mediator);
+			mediator.OnRegister ();
+			view.registeredWithContext = true;
+		}
+	}
+
+	class TestView : IView
+	{
+		[Inject]
+		public ClassToBeInjected testInjection { get; set; }
+
+		#region IView implementation
+
+		private bool _requiresContext;
+		private bool _registeredWithContext;
+
+		public bool requiresContext
+		{
+			get
+			{
+				return _requiresContext;
+			}
+			set
+			{
+				_requiresContext = value;
+			}
+		}
+
+		public bool registeredWithContext
+		{
+			get
+			{
+				return _registeredWithContext;
+			}
+			set
+			{
+				_registeredWithContext = value;
+			}
+		}
+
+		public bool autoRegisterWithContext
+		{
+			get
+			{
+				return true;
+			}
+		}
+
+		#endregion
+	}
+
+	class TestMediator : IMediator
+	{
+		public bool preregistered = false;
+		public bool registered = false;
+		public bool removed = false;
+
+		#region IMediator implementation
+
+		public void PreRegister ()
+		{
+			preregistered = true;
+		}
+
+		public void OnRegister ()
+		{
+			registered = true;
+		}
+
+		public void OnRemove ()
+		{
+			removed = true;
+		}
+
+		public UnityEngine.GameObject contextView
+		{
+			get
+			{
+				throw new NotImplementedException ();
+			}
+			set
+			{
+				throw new NotImplementedException ();
+			}
+		}
+
+		#endregion
+	}
+}
+

--- a/StrangeIoC/scripts/strange/.tests/extensions/mediation/TestAbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/mediation/TestAbstractMediationBinder.cs
@@ -185,6 +185,22 @@ namespace strange.unittests
 		}
 
 		[Test]
+		public void TestBindViewToMediatorSyntax()
+		{
+			string jsonString = "[{\"BindView\":\"strange.unittests.TestView\",\"ToMediator\":[\"strange.unittests.TestMediator\",\"strange.unittests.TestMediator2\"]}]";
+
+			mediationBinder.ConsumeBindings (jsonString);
+
+			IBinding binding = mediationBinder.GetBinding<TestView> ();
+			Assert.NotNull (binding);
+			Assert.AreEqual ((binding as IMediationBinding).key, typeof(TestView));
+
+			object[] value = (binding as IMediationBinding).value as object[];
+			Assert.Contains (typeof(TestMediator), value);
+			Assert.Contains (typeof(TestMediator2), value);
+		}
+
+		[Test]
 		public void TestThrowsErrorOnUnresolvedView()
 		{
 			string jsonString = "[{\"Bind\":\"TestView\",\"To\":\"strange.unittests.TestMediator\"}]";

--- a/StrangeIoC/scripts/strange/.tests/extensions/mediation/TestAbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/mediation/TestAbstractMediationBinder.cs
@@ -104,6 +104,30 @@ namespace strange.unittests
 			MediationException ex = Assert.Throws<MediationException>(testDelegate); //Because we've mapped view to self
 			Assert.AreEqual (MediationExceptionType.MEDIATOR_VIEW_STACK_OVERFLOW, ex.type);
 		}
+
+		[Test]
+		public void TestInjectViews()
+		{
+			injectionBinder.Bind<ClassToBeInjected>().To<ClassToBeInjected>();
+			object mono = new object();
+			IView one = new TestView();
+			IView two = new TestView();
+			IView three = new TestView();
+
+			IView[] views =
+			{
+				one,
+				two,
+				three
+			};
+
+			mediationBinder.TestInjectViews(mono, views);
+
+			Assert.AreEqual(true, one.registeredWithContext);
+			Assert.AreEqual(true, two.registeredWithContext);
+			Assert.AreEqual(true, three.registeredWithContext);
+
+		}
 	}
 
 
@@ -122,6 +146,11 @@ namespace strange.unittests
 			IMediator mediator = new TestMediator ();
 			mediators.Add (view, mediator);
 			return mediator;
+		}
+
+		public void TestInjectViews(object mono, IView[] views)
+		{
+			InjectViews(mono, views);
 		}
 
 		override protected object DestroyMediator(IView view, Type mediatorType)

--- a/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
@@ -35,14 +35,31 @@ namespace strange.extensions.mediation
 	{
 
 		/// Adds a Mediator to a View
-		protected override MonoBehaviour createMediator(MonoBehaviour mono, Type mediatorType)
+		protected override object CreateMediator(IView view, Type mediatorType)
 		{
-			MonoBehaviour mediator = base.createMediator(mono, mediatorType);
+			MonoBehaviour mediator = base.CreateMediator(view, mediatorType) as MonoBehaviour;
 			if (mediator is IMediator)
 			{
 				HandleDelegates(mediator, mediatorType, true);
 			}
 			return mediator;
+		}
+
+		/// Manage Delegates, then remove the Mediator from a View
+		protected override object DestroyMediator(IView view, Type mediatorType)
+		{
+			MonoBehaviour mono = view as MonoBehaviour;
+			IMediator mediator = mono.GetComponent(mediatorType) as IMediator;
+			//Unbind signals from methods
+			if (mediator != null)
+			{
+				HandleDelegates ((MonoBehaviour) mediator, mediatorType, false);
+				return base.DestroyMediator (mediator);
+			}
+			else
+			{
+				return null;
+			}
 		}
 
 		/// Determine whether to add or remove ListensTo delegates
@@ -90,15 +107,6 @@ namespace strange.extensions.mediation
 			{
 				((Signal)signal).AddListener((Action)Delegate.CreateDelegate(typeof(Action), mediator, method)); //Assign and cast explicitly for Type == Signal case
 			}
-
-		}
-
-		/// Manage Delegates, then remove the Mediator from a View
-		protected override void removeMediator(IMediator mediator)
-		{
-			//Unbind signals to methods
-			HandleDelegates((MonoBehaviour)mediator, mediator.GetType(), false);
-			base.removeMediator(mediator);
 		}
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/mediation/api/IMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/api/IMediationBinder.cs
@@ -78,7 +78,7 @@ namespace strange.extensions.mediation.api
 		new IMediationBinding Bind<T> ();
 
 		/// Porcelain for Bind<T> providing a little extra clarity and security.
-		IMediationBinding BindView<T> () where T : MonoBehaviour;
+		IMediationBinding BindView<T> ();
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/mediation/api/IMediationBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/api/IMediationBinding.cs
@@ -37,6 +37,8 @@ namespace strange.extensions.mediation.api
 		/// instead of the concrete View class.
 		IMediationBinding ToAbstraction<T>();
 
+		IMediationBinding ToAbstraction(Type t);
+
 		/// Retrieve the abstracted value set by ToAbstraction<T>
 		object abstraction { get; }
 

--- a/StrangeIoC/scripts/strange/extensions/mediation/api/MediationExceptionType.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/api/MediationExceptionType.cs
@@ -36,6 +36,10 @@ namespace strange.extensions.mediation.api
 		/// infinite loop of Mediation creation.
 		MEDIATOR_VIEW_STACK_OVERFLOW,
 
+		/// A Binding resolved to null as it was converted (usually from a Binding)
+		/// Honestly, this should never happen.
+		BINDING_RESOLVED_TO_NULL,
+
 		/// Exception raised when AddComponent results in a null Mediator.
 		/// This probably means that the mapped "mediator" wasn't a MonoBehaviour.
 		NULL_MEDIATOR,

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
@@ -70,7 +70,7 @@ namespace strange.extensions.mediation.impl
 		}
 
 		/// Add a Mediator to a View. If the mediator is a "true" Mediator (i.e., it
-		/// implements IMediator, perform PreRegister and OnRegister.
+		/// implements IMediator), perform PreRegister and OnRegister.
 		protected virtual void ApplyMediationToView(IMediationBinding binding, IView view, Type mediatorType)
 		{
 			bool isTrueMediator = IsTrueMediator(mediatorType);
@@ -78,8 +78,9 @@ namespace strange.extensions.mediation.impl
 			{
 				Type viewType = view.GetType();
 				object mediator = CreateMediator(view, mediatorType);
+
 				if (mediator == null)
-					throw new MediationException("The view: " + viewType.ToString() + " is mapped to mediator: " + mediatorType.ToString() + ". AddComponent resulted in null, which probably means " + mediatorType.ToString().Substring(mediatorType.ToString().LastIndexOf(".") + 1) + " is not a MonoBehaviour.", MediationExceptionType.NULL_MEDIATOR);
+					ThrowNullMediatorError (viewType, mediatorType);
 				if (isTrueMediator)
 					((IMediator)mediator).PreRegister();
 
@@ -117,12 +118,12 @@ namespace strange.extensions.mediation.impl
 			}
 			injectionBinder.injector.Inject(view, false);
 		}
+
 		protected virtual bool IsTrueMediator(Type mediatorType)
 		{
 			return typeof(IMediator).IsAssignableFrom(mediatorType);
 		}
 
-		
 		override protected IBinding performKeyValueBindings(List<object> keyList, List<object> valueList)
 		{
 			IBinding binding = null;
@@ -206,13 +207,11 @@ namespace strange.extensions.mediation.impl
 			}
 		}
 
-		/// Initialize all IViews within this view
-
 		/// Create a new Mediator object based on the mediatorType on the provided view
-		abstract protected object CreateMediator(IView view, Type mediatorType);
+		protected abstract object CreateMediator(IView view, Type mediatorType);
 
 		/// Destroy the Mediator on the provided view object based on the mediatorType
-		abstract protected object DestroyMediator(IView view, Type mediatorType);
+		protected abstract object DestroyMediator(IView view, Type mediatorType);
 
 		/// Retrieve all views including children for this view
 		protected abstract IView[] GetViews(IView view);
@@ -220,7 +219,10 @@ namespace strange.extensions.mediation.impl
 		/// Whether or not an instantiated Mediator of this type exists
 		protected abstract bool HasMediator(IView view, Type mediatorType);
 
-		
+		/// Error thrown when a Mediator can't be instantiated
+		/// Abstract because this happens for different reasons. Allow implementing
+		/// class to specify the nature of the error.
+		protected abstract void ThrowNullMediatorError(Type viewType, Type mediatorType);
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
@@ -158,6 +158,31 @@ namespace strange.extensions.mediation.impl
 			return binding;
 		}
 
+		override protected Dictionary<string, object> ConformRuntimeItem(Dictionary<string, object> dictionary)
+		{
+			Dictionary<string, object> bindItems = new Dictionary<string, object> ();
+			Dictionary<string, object> toItems = new Dictionary<string, object> ();
+			foreach (var item in dictionary) {
+				if (item.Key == "BindView")
+				{
+					bindItems.Add ("Bind", item.Value);
+				}
+				else if (item.Key == "ToMediator")
+				{
+					toItems.Add ("To", item.Value);
+				}
+			}
+			foreach (var item in bindItems) {
+				dictionary.Remove ("BindView");
+				dictionary.Add ("Bind", item.Value);
+			}
+			foreach (var item in toItems) {
+				dictionary.Remove ("ToMediator");
+				dictionary.Add ("To", item.Value);
+			}
+			return dictionary;
+		}
+
 		new public IMediationBinding Bind<T> ()
 		{
 			return base.Bind<T> () as IMediationBinding;

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
@@ -136,14 +136,7 @@ namespace strange.extensions.mediation.impl
 				{
 					throw new BinderException ("A runtime Mediation Binding has resolved to null. Did you forget to register its fully-qualified name?\n View:" + key, BinderExceptionType.RUNTIME_NULL_VALUE);
 				}
-				if (binding == null)
-				{
-					binding = Bind (keyType);
-				}
-				else
-				{
-					binding = binding.Bind (keyType);
-				}
+				binding = Bind (keyType);
 			}
 			foreach (object value in valueList)
 			{

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
@@ -69,6 +69,26 @@ namespace strange.extensions.mediation.impl
 			}
 		}
 
+		protected virtual void InjectViews(object mono, IView[] views)
+		{
+			int aa = views.Length;
+			for (int a = aa - 1; a > -1; a--)
+			{
+				IView iView = views[a] as IView;
+				if (iView != null)
+				{
+					if (iView.autoRegisterWithContext && iView.registeredWithContext)
+					{
+						continue;
+					}
+					iView.registeredWithContext = true;
+					if (iView.Equals(mono) == false)
+						Trigger(MediationEvent.AWAKE, iView);
+				}
+			}
+			injectionBinder.injector.Inject(mono, false);
+		}
+
 		override protected IBinding performKeyValueBindings(List<object> keyList, List<object> valueList)
 		{
 			IBinding binding = null;

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
@@ -183,6 +183,31 @@ namespace strange.extensions.mediation.impl
 			return dictionary;
 		}
 
+		override protected IBinding ConsumeItem(Dictionary<string, object> item, IBinding testBinding)
+		{
+			IBinding binding = base.ConsumeItem(item, testBinding);
+
+			foreach (var i in item)
+			{
+				if (i.Key == "ToAbstraction")
+				{
+					Type abstractionType = Type.GetType (i.Value as string);
+					IMediationBinding mediationBinding = (binding as IMediationBinding);
+					if (abstractionType == null)
+					{
+						throw new BinderException ("A runtime abstraction in the MediationBinder returned a null Type. " + i.ToString(), BinderExceptionType.RUNTIME_NULL_VALUE);
+					}
+					if (mediationBinding == null)
+					{
+						throw new MediationException ("During an attempt at runtime abstraction a MediationBinding could not be found. " + i.ToString(), MediationExceptionType.BINDING_RESOLVED_TO_NULL);
+					}
+
+					mediationBinding.ToAbstraction (abstractionType);
+				}
+			}
+			return binding;
+		}
+
 		new public IMediationBinding Bind<T> ()
 		{
 			return base.Bind<T> () as IMediationBinding;

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
@@ -1,0 +1,175 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+/**
+ * @class strange.extensions.mediation.impl.MediationBinder
+ * 
+ * Highest-level abstraction of the MediationBinder. Agnostic as to View and Mediator Type.
+ * 
+ * Please read strange.extensions.mediation.api.IMediationBinder
+ * where I've extensively explained the purpose of View mediation
+ */
+
+using System;
+using strange.extensions.injector.api;
+using strange.extensions.mediation.api;
+using strange.framework.api;
+using strange.framework.impl;
+using System.Collections.Generic;
+
+namespace strange.extensions.mediation.impl
+{
+	abstract public class AbstractMediationBinder : Binder, IMediationBinder
+	{
+
+		[Inject]
+		public IInjectionBinder injectionBinder{ get; set;}
+
+		public AbstractMediationBinder ()
+		{
+		}
+
+
+		public override IBinding GetRawBinding ()
+		{
+			return new MediationBinding (resolver) as IBinding;
+		}
+
+		public void Trigger(MediationEvent evt, IView view)
+		{
+			Type viewType = view.GetType();
+			IMediationBinding binding = GetBinding (viewType) as IMediationBinding;
+			if (binding != null)
+			{
+				switch(evt)
+				{
+					case MediationEvent.AWAKE:
+						InjectViewAndChildren(view);
+						MapView (view, binding);
+						break;
+					case MediationEvent.DESTROYED:
+						UnmapView (view, binding);
+						break;
+					default:
+						break;
+				}
+			}
+			else if (evt == MediationEvent.AWAKE)
+			{
+				//Even if not mapped, Views (and their children) have potential to be injected
+				InjectViewAndChildren(view);
+			}
+		}
+
+		override protected IBinding performKeyValueBindings(List<object> keyList, List<object> valueList)
+		{
+			IBinding binding = null;
+
+			// Bind in order
+			foreach (object key in keyList)
+			{
+				Type keyType = Type.GetType (key as string);
+				if (keyType == null)
+				{
+					throw new BinderException ("A runtime Mediation Binding has resolved to null. Did you forget to register its fully-qualified name?\n View:" + key, BinderExceptionType.RUNTIME_NULL_VALUE);
+				}
+				if (binding == null)
+				{
+					binding = Bind (keyType);
+				}
+				else
+				{
+					binding = binding.Bind (keyType);
+				}
+			}
+			foreach (object value in valueList)
+			{
+				Type valueType = Type.GetType (value as string);
+				if (valueType == null)
+				{
+					throw new BinderException ("A runtime Mediation Binding has resolved to null. Did you forget to register its fully-qualified name?\n Mediator:" + value, BinderExceptionType.RUNTIME_NULL_VALUE);
+				}
+				binding = binding.To (valueType);
+			}
+
+			return binding;
+		}
+
+		new public IMediationBinding Bind<T> ()
+		{
+			return base.Bind<T> () as IMediationBinding;
+		}
+
+		public IMediationBinding BindView<T>()
+		{
+			return base.Bind<T> () as IMediationBinding;
+		}
+
+		/// Creates and registers one or more Mediators for a specific View instance.
+		/// Takes a specific View instance and a binding and, if a binding is found for that type, creates and registers a Mediator.
+		virtual protected void MapView(IView view, IMediationBinding binding)
+		{
+			Type viewType = view.GetType();
+
+			if (bindings.ContainsKey (viewType))
+			{
+				object[] values = binding.value as object[];
+				int aa = values.Length;
+				for (int a = 0; a < aa; a++)
+				{
+					Type mediatorType = values [a] as Type;
+					if (mediatorType == viewType)
+					{
+						throw new MediationException(viewType + "mapped to itself. The result would be a stack overflow.", MediationExceptionType.MEDIATOR_VIEW_STACK_OVERFLOW);
+					}
+					ApplyMediationToView (binding, view, mediatorType);
+				}
+			}
+		}
+
+		/// Removes a mediator when its view is destroyed
+		virtual protected void UnmapView(IView view, IMediationBinding binding)
+		{
+			Type viewType = view.GetType();
+
+			if (bindings.ContainsKey(viewType))
+			{
+				object[] values = binding.value as object[];
+				int aa = values.Length;
+				for (int a = 0; a < aa; a++)
+				{
+					Type mediatorType = values[a] as Type;
+					DestroyMediator (view, mediatorType);
+				}
+			}
+		}
+
+		/// Initialize all IViews within this view
+		abstract protected void InjectViewAndChildren(IView view);
+
+		/// Create a new Mediator object based on the mediatorType on the provided view
+		abstract protected object CreateMediator(IView view, Type mediatorType);
+
+		/// Destroy the Mediator on the provided view object based on the mediatorType
+		abstract protected object DestroyMediator(IView view, Type mediatorType);
+
+		/// Add Mediators to Views. We make this abstract to allow for different concrete
+		/// behaviors for different View/Mediation Types (e.g., MonoBehaviours require 
+		/// different handling than EditorWindows)
+		abstract protected void ApplyMediationToView(IMediationBinding binding, IView view, Type mediatorType);
+	}
+}
+

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
@@ -38,11 +38,6 @@ namespace strange.extensions.mediation.impl
 		[Inject]
 		public IInjectionBinder injectionBinder{ get; set;}
 
-		public AbstractMediationBinder ()
-		{
-		}
-
-
 		public override IBinding GetRawBinding ()
 		{
 			return new MediationBinding (resolver) as IBinding;

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs.meta
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4064de17cb8135e48873688ed096959f
+timeCreated: 1435962480
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -27,7 +27,6 @@
 using System;
 using UnityEngine;
 using strange.extensions.mediation.api;
-using strange.framework.api;
 
 namespace strange.extensions.mediation.impl
 {
@@ -38,40 +37,16 @@ namespace strange.extensions.mediation.impl
 		{
 		}
 
-		
-		/// Initialize all IViews within this view
-		protected override void InjectViewAndChildren(IView view)
+		protected override IView[] GetViews(IView view)
 		{
 			MonoBehaviour mono = view as MonoBehaviour;
-			IView[] views = mono.GetComponentsInChildren(typeof(IView), true) as IView[];
-			
-			InjectViews(mono, views);
+			return mono.GetComponentsInChildren(typeof(IView), true) as IView[];
 		}
 
-		/// Add a Mediator to a View. If the mediator is a "true" Mediator (i.e., it
-		/// implements IMediator, perform PreRegister and OnRegister.
-		protected override void ApplyMediationToView(IMediationBinding binding, IView view, Type mediatorType)
+		protected override bool HasMediator(IView view, Type mediatorType)
 		{
-			bool isTrueMediator = mediatorType.IsAssignableFrom (typeof(IMediator));
 			MonoBehaviour mono = view as MonoBehaviour;
-			if (!isTrueMediator || mono.GetComponent (mediatorType) == null)
-			{
-				Type viewType = view.GetType();
-				MonoBehaviour mediator = CreateMediator(view, mediatorType) as MonoBehaviour;
-				if (mediator == null)
-					throw new MediationException ("The view: " + viewType.ToString() + " is mapped to mediator: " + mediatorType.ToString() + ". AddComponent resulted in null, which probably means " + mediatorType.ToString().Substring(mediatorType.ToString().LastIndexOf(".")+1) + " is not a MonoBehaviour.", MediationExceptionType.NULL_MEDIATOR);
-				if (isTrueMediator)
-					((IMediator)mediator).PreRegister ();
-
-				Type typeToInject = (binding.abstraction == null || binding.abstraction.Equals(BindingConst.NULLOID)) ? viewType : binding.abstraction as Type;
-				injectionBinder.Bind (typeToInject).ToValue (view).ToInject(false);
-				injectionBinder.injector.Inject (mediator);
-				injectionBinder.Unbind(typeToInject);
-				if (isTrueMediator)
-				{
-					((IMediator) mediator).OnRegister ();
-				}
-			}
+			return mono.GetComponent(mediatorType) != null;
 		}
 
 		/// Create a new Mediator object based on the mediatorType on the provided view

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -61,11 +61,7 @@ namespace strange.extensions.mediation.impl
 		{
 			MonoBehaviour mono = view as MonoBehaviour;
 			IMediator mediator = mono.GetComponent(mediatorType) as IMediator;
-			if (mediator != null)
-			{
-				DestroyMediator (mediator);
-			}
-			return DestroyMediator (mediator);
+			return (mediator != null) ? DestroyMediator (mediator) : null;
 		}
 
 		/// Destroy the provided Mediator
@@ -73,6 +69,11 @@ namespace strange.extensions.mediation.impl
 		{
 			mediator.OnRemove();
 			return mediator;
+		}
+
+		protected override void ThrowNullMediatorError (Type viewType, Type mediatorType)
+		{
+			throw new MediationException("The view: " + viewType.ToString() + " is mapped to mediator: " + mediatorType.ToString() + ". AddComponent resulted in null, which probably means " + mediatorType.ToString().Substring(mediatorType.ToString().LastIndexOf(".") + 1) + " is not a MonoBehaviour.", MediationExceptionType.NULL_MEDIATOR);
 		}
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -43,25 +43,9 @@ namespace strange.extensions.mediation.impl
 		protected override void InjectViewAndChildren(IView view)
 		{
 			MonoBehaviour mono = view as MonoBehaviour;
-			Component[] views = mono.GetComponentsInChildren(typeof(IView), true) as Component[];
+			IView[] views = mono.GetComponentsInChildren(typeof(IView), true) as IView[];
 			
-			int aa = views.Length;
-			for (int a = aa - 1; a > -1; a--)
-			{
-				IView iView = views[a] as IView;
-				if (iView != null)
-				{
-					if (iView.autoRegisterWithContext && iView.registeredWithContext)
-					{
-						continue;
-					}
-					iView.registeredWithContext = true;
-					if (iView.Equals(mono) == false)
-						Trigger (MediationEvent.AWAKE, iView);
-				}
-			}
-			injectionBinder.injector.Inject (mono, false);
-
+			InjectViews(mono, views);
 		}
 
 		/// Add a Mediator to a View. If the mediator is a "true" Mediator (i.e., it

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -17,101 +17,30 @@
 /**
  * @class strange.extensions.mediation.impl.MediationBinder
  * 
- * Binds Views to Mediators.
+ * Binds Views to Mediators. This is the base class for all MediationBinders
+ * that work with MonoBehaviours.
  * 
  * Please read strange.extensions.mediation.api.IMediationBinder
  * where I've extensively explained the purpose of View mediation
  */
 
 using System;
-using System.Collections;
 using UnityEngine;
-using strange.extensions.injector.api;
 using strange.extensions.mediation.api;
 using strange.framework.api;
-using strange.framework.impl;
-using System.Collections.Generic;
 
 namespace strange.extensions.mediation.impl
 {
-	public class MediationBinder : Binder, IMediationBinder
+	public class MediationBinder : AbstractMediationBinder, IMediationBinder
 	{
-
-		[Inject]
-		public IInjectionBinder injectionBinder{ get; set;}
 
 		public MediationBinder ()
 		{
 		}
 
-
-		public override IBinding GetRawBinding ()
-		{
-			return new MediationBinding (resolver) as IBinding;
-		}
-
-		public void Trigger(MediationEvent evt, IView view)
-		{
-			Type viewType = view.GetType();
-			IMediationBinding binding = GetBinding (viewType) as IMediationBinding;
-			if (binding != null)
-			{
-				switch(evt)
-				{
-					case MediationEvent.AWAKE:
-						injectViewAndChildren(view);
-						mapView (view, binding);
-						break;
-					case MediationEvent.DESTROYED:
-						unmapView (view, binding);
-						break;
-					default:
-						break;
-				}
-			}
-			else if (evt == MediationEvent.AWAKE)
-			{
-				//Even if not mapped, Views (and their children) have potential to be injected
-				injectViewAndChildren(view);
-			}
-		}
-
-		override protected IBinding performKeyValueBindings(List<object> keyList, List<object> valueList)
-		{
-			IBinding binding = null;
-
-			// Bind in order
-			foreach (object key in keyList)
-			{
-				Type keyType = Type.GetType (key as string);
-				if (keyType == null)
-				{
-					throw new BinderException ("A runtime Mediation Binding has resolved to null. Did you forget to register its fully-qualified name?\n View:" + key, BinderExceptionType.RUNTIME_NULL_VALUE);
-				}
-				if (binding == null)
-				{
-					binding = Bind (keyType);
-				}
-				else
-				{
-					binding = binding.Bind (keyType);
-				}
-			}
-			foreach (object value in valueList)
-			{
-				Type valueType = Type.GetType (value as string);
-				if (valueType == null)
-				{
-					throw new BinderException ("A runtime Mediation Binding has resolved to null. Did you forget to register its fully-qualified name?\n Mediator:" + value, BinderExceptionType.RUNTIME_NULL_VALUE);
-				}
-				binding = binding.To (valueType);
-			}
-
-			return binding;
-		}
 		
 		/// Initialize all IViews within this view
-		virtual protected void injectViewAndChildren(IView view)
+		protected override void InjectViewAndChildren(IView view)
 		{
 			MonoBehaviour mono = view as MonoBehaviour;
 			Component[] views = mono.GetComponentsInChildren(typeof(IView), true) as Component[];
@@ -135,94 +64,56 @@ namespace strange.extensions.mediation.impl
 
 		}
 
-		new public IMediationBinding Bind<T> ()
+		/// Add a Mediator to a View. If the mediator is a "true" Mediator (i.e., it
+		/// implements IMediator, perform PreRegister and OnRegister.
+		protected override void ApplyMediationToView(IMediationBinding binding, IView view, Type mediatorType)
 		{
-			return base.Bind<T> () as IMediationBinding;
-		}
-
-		public IMediationBinding BindView<T>() where T : MonoBehaviour
-		{
-			return base.Bind<T> () as IMediationBinding;
-		}
-
-		/// Creates and registers one or more Mediators for a specific View instance.
-		/// Takes a specific View instance and a binding and, if a binding is found for that type, creates and registers a Mediator.
-		virtual protected void mapView(IView view, IMediationBinding binding)
-		{
-			Type viewType = view.GetType();
-
-			if (bindings.ContainsKey(viewType))
+			bool isTrueMediator = mediatorType.IsAssignableFrom (typeof(IMediator));
+			MonoBehaviour mono = view as MonoBehaviour;
+			if (!isTrueMediator || mono.GetComponent (mediatorType) == null)
 			{
-				object[] values = binding.value as object[];
-				int aa = values.Length;
-				for (int a = 0; a < aa; a++)
-				{
-					MonoBehaviour mono = view as MonoBehaviour;
-					Type mediatorType = values [a] as Type;
-					if (mediatorType == viewType)
-					{
-						throw new MediationException(viewType + "mapped to itself. The result would be a stack overflow.", MediationExceptionType.MEDIATOR_VIEW_STACK_OVERFLOW);
-					}
-					bool isTrueMediator = mediatorType.IsAssignableFrom (typeof(IMediator));
-					if (!isTrueMediator || mono.GetComponent (mediatorType) == null)
-					{
-						MonoBehaviour mediator = createMediator(mono, mediatorType);
-						if (mediator == null)
-							throw new MediationException ("The view: " + viewType.ToString() + " is mapped to mediator: " + mediatorType.ToString() + ". AddComponent resulted in null, which probably means " + mediatorType.ToString().Substring(mediatorType.ToString().LastIndexOf(".")+1) + " is not a MonoBehaviour.", MediationExceptionType.NULL_MEDIATOR);
-						if (isTrueMediator)
-							((IMediator)mediator).PreRegister ();
+				Type viewType = view.GetType();
+				MonoBehaviour mediator = CreateMediator(view, mediatorType) as MonoBehaviour;
+				if (mediator == null)
+					throw new MediationException ("The view: " + viewType.ToString() + " is mapped to mediator: " + mediatorType.ToString() + ". AddComponent resulted in null, which probably means " + mediatorType.ToString().Substring(mediatorType.ToString().LastIndexOf(".")+1) + " is not a MonoBehaviour.", MediationExceptionType.NULL_MEDIATOR);
+				if (isTrueMediator)
+					((IMediator)mediator).PreRegister ();
 
-						Type typeToInject = (binding.abstraction == null || binding.abstraction.Equals(BindingConst.NULLOID)) ? viewType : binding.abstraction as Type;
-						injectionBinder.Bind (typeToInject).ToValue (view).ToInject(false);
-						injectionBinder.injector.Inject (mediator);
-						injectionBinder.Unbind(typeToInject);
-						if (isTrueMediator)
-						{
-							((IMediator) mediator).OnRegister ();
-						}
-					}
+				Type typeToInject = (binding.abstraction == null || binding.abstraction.Equals(BindingConst.NULLOID)) ? viewType : binding.abstraction as Type;
+				injectionBinder.Bind (typeToInject).ToValue (view).ToInject(false);
+				injectionBinder.injector.Inject (mediator);
+				injectionBinder.Unbind(typeToInject);
+				if (isTrueMediator)
+				{
+					((IMediator) mediator).OnRegister ();
 				}
 			}
 		}
 
-		virtual protected MonoBehaviour createMediator(MonoBehaviour mono, Type mediatorType)
+		/// Create a new Mediator object based on the mediatorType on the provided view
+		protected override object CreateMediator(IView view, Type mediatorType)
 		{
-			return mono.gameObject.AddComponent(mediatorType) as MonoBehaviour;
+			MonoBehaviour mono = view as MonoBehaviour;
+			return mono.gameObject.AddComponent(mediatorType);
 		}
 
-		virtual protected void removeMediator(IMediator mediator)
+		/// Destroy the Mediator on the provided view object based on the mediatorType
+		protected override object DestroyMediator(IView view, Type mediatorType)
+		{
+			MonoBehaviour mono = view as MonoBehaviour;
+			IMediator mediator = mono.GetComponent(mediatorType) as IMediator;
+			if (mediator != null)
+			{
+				DestroyMediator (mediator);
+			}
+			return DestroyMediator (mediator);
+		}
+
+		/// Destroy the provided Mediator
+		protected object DestroyMediator(IMediator mediator)
 		{
 			mediator.OnRemove();
-		}
-
-		/// Removes a mediator when its view is destroyed
-		virtual protected void unmapView(IView view, IMediationBinding binding)
-		{
-			Type viewType = view.GetType();
-
-			if (bindings.ContainsKey(viewType))
-			{
-				object[] values = binding.value as object[];
-				int aa = values.Length;
-				for (int a = 0; a < aa; a++)
-				{
-					Type mediatorType = values[a] as Type;
-					MonoBehaviour mono = view as MonoBehaviour;
-					IMediator mediator = mono.GetComponent(mediatorType) as IMediator;
-					if (mediator != null)
-					{
-						removeMediator(mediator);
-					}
-				}
-			}
-		}
-
-		private void enableView(IView view)
-		{
-		}
-
-		private void disableView(IView view)
-		{
+			return mediator;
 		}
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinder.cs
@@ -25,6 +25,7 @@
  */
 
 using System;
+using System.Linq;
 using UnityEngine;
 using strange.extensions.mediation.api;
 
@@ -40,7 +41,9 @@ namespace strange.extensions.mediation.impl
 		protected override IView[] GetViews(IView view)
 		{
 			MonoBehaviour mono = view as MonoBehaviour;
-			return mono.GetComponentsInChildren(typeof(IView), true) as IView[];
+			Component[] components = mono.GetComponentsInChildren (typeof(IView), true);
+			IView[] views = components.Cast<IView>().ToArray();
+			return views;
 		}
 
 		protected override bool HasMediator(IView view, Type mediatorType)

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinding.cs
@@ -53,16 +53,7 @@ namespace strange.extensions.mediation.impl
 
 		IMediationBinding IMediationBinding.ToAbstraction<T> ()
 		{
-			Type t = typeof (T);
-			Type abstractionType = t;
-			if (key != null)
-			{
-				Type keyType = key as Type;
-				if (abstractionType.IsAssignableFrom(keyType) == false)
-					throw new MediationException ("The View " + key.ToString() + " has been bound to the abstraction " + t.ToString() + " which the View neither extends nor implements. " , MediationExceptionType.VIEW_NOT_ASSIGNABLE);
-			}
-			_abstraction.Add (abstractionType);
-			return this;
+			return ((IMediationBinding)this).ToAbstraction(typeof (T));
 		}
 
 		IMediationBinding IMediationBinding.ToAbstraction (Type t)

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinding.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/MediationBinding.cs
@@ -19,8 +19,13 @@
  * 
  * Subclass of Binding for MediationBinding.
  * 
- * I've provided MediationBinding, but at present it comforms
- * perfectly to Binding.
+ * MediationBindings support the following extensions of standard Bindings:
+ *
+ * ToMediator - Porcelain for To<T> providing a little extra clarity and security.
+ *
+ * ToAbstraction<T> - Provide an Interface or base Class adapter for the View.
+ * When the binding specifies ToAbstraction<T>, the Mediator will be expected to inject <T>
+ * instead of the concrete View class.
  */
 
 using System;
@@ -48,12 +53,26 @@ namespace strange.extensions.mediation.impl
 
 		IMediationBinding IMediationBinding.ToAbstraction<T> ()
 		{
-			Type abstractionType = typeof(T);
+			Type t = typeof (T);
+			Type abstractionType = t;
 			if (key != null)
 			{
 				Type keyType = key as Type;
 				if (abstractionType.IsAssignableFrom(keyType) == false)
-					throw new MediationException ("The View " + key.ToString() + " has been bound to the abstraction " + typeof(T).ToString() + " which the View neither extends nor implements. " , MediationExceptionType.VIEW_NOT_ASSIGNABLE);
+					throw new MediationException ("The View " + key.ToString() + " has been bound to the abstraction " + t.ToString() + " which the View neither extends nor implements. " , MediationExceptionType.VIEW_NOT_ASSIGNABLE);
+			}
+			_abstraction.Add (abstractionType);
+			return this;
+		}
+
+		IMediationBinding IMediationBinding.ToAbstraction (Type t)
+		{
+			Type abstractionType = t;
+			if (key != null)
+			{
+				Type keyType = key as Type;
+				if (abstractionType.IsAssignableFrom(keyType) == false)
+					throw new MediationException ("The View " + key.ToString() + " has been bound to the abstraction " + t.ToString() + " which the View neither extends nor implements. " , MediationExceptionType.VIEW_NOT_ASSIGNABLE);
 			}
 			_abstraction.Add (abstractionType);
 			return this;

--- a/StrangeIoC/scripts/strange/framework/impl/Binder.cs
+++ b/StrangeIoC/scripts/strange/framework/impl/Binder.cs
@@ -349,44 +349,51 @@ namespace strange.framework.impl
 		{
 			List<object> list = Json.Deserialize(jsonString) as List<object>;
 			IBinding testBinding = GetRawBinding ();
-			int bindConstraints = (testBinding.keyConstraint == BindingConstraintType.ONE) ? 0 : 1;
-			bindConstraints |= (testBinding.valueConstraint == BindingConstraintType.ONE) ? 0 : 2;
 
 			for (int a=0, aa=list.Count; a < aa; a++)
 			{
-				Dictionary<string, object> item = list[a] as Dictionary<string, object>;
-				item = ConformRuntimeItem (item);
-				List<object> keyList;
-				List<object> valueList;
-				IBinding binding = null;
+				ConsumeItem(list[a] as Dictionary<string, object>, testBinding);
+			}
+		}
 
+		virtual protected IBinding ConsumeItem(Dictionary<string, object> item, IBinding testBinding)
+		{
+			int bindConstraints = (testBinding.keyConstraint == BindingConstraintType.ONE) ? 0 : 1;
+			bindConstraints |= (testBinding.valueConstraint == BindingConstraintType.ONE) ? 0 : 2;
+			IBinding binding = null;
+			List<object> keyList;
+			List<object> valueList;
+
+			if (item != null)
+			{
+				item = ConformRuntimeItem (item);
 				// Check that Bind exists
-				if (!item.ContainsKey("Bind"))
+				if (!item.ContainsKey ("Bind"))
 				{
 					throw new BinderException ("Attempted to consume a binding without a bind key.", BinderExceptionType.RUNTIME_NO_BIND);
 				}
 				else
 				{
-					keyList = conformRuntimeToList(item["Bind"]);
+					keyList = conformRuntimeToList (item ["Bind"]);
 				}
 				// Check that key counts match the binding constraint
 				if (keyList.Count > 1 && (bindConstraints & 1) == 0)
 				{
-					throw new BinderException ("Binder " + this.ToString () + " supports only a single binding key. A runtime binding key including " + keyList[0].ToString() + " is trying to add more.", BinderExceptionType.RUNTIME_TOO_MANY_KEYS);
+					throw new BinderException ("Binder " + this.ToString () + " supports only a single binding key. A runtime binding key including " + keyList [0].ToString () + " is trying to add more.", BinderExceptionType.RUNTIME_TOO_MANY_KEYS);
 				}
 
-				if (!item.ContainsKey("To"))
+				if (!item.ContainsKey ("To"))
 				{
 					valueList = keyList;
 				}
 				else
 				{
-					valueList = conformRuntimeToList(item["To"]);
+					valueList = conformRuntimeToList (item ["To"]);
 				}
 				// Check that value counts match the binding constraint
 				if (valueList.Count > 1 && (bindConstraints & 2) == 0)
 				{
-					throw new BinderException ("Binder " + this.ToString () + " supports only a single binding value. A runtime binding value including " + valueList[0].ToString() + " is trying to add more.", BinderExceptionType.RUNTIME_TOO_MANY_VALUES);
+					throw new BinderException ("Binder " + this.ToString () + " supports only a single binding value. A runtime binding value including " + valueList [0].ToString () + " is trying to add more.", BinderExceptionType.RUNTIME_TOO_MANY_VALUES);
 				}
 
 				// Check Whitelist if it exists
@@ -394,9 +401,9 @@ namespace strange.framework.impl
 				{
 					foreach (object value in valueList)
 					{
-						if (bindingWhitelist.IndexOf(value) == -1)
+						if (bindingWhitelist.IndexOf (value) == -1)
 						{
-							throw new BinderException ("Value " + value.ToString () + " not found on whitelist for " + this.ToString() + ".", BinderExceptionType.RUNTIME_FAILED_WHITELIST_CHECK);
+							throw new BinderException ("Value " + value.ToString () + " not found on whitelist for " + this.ToString () + ".", BinderExceptionType.RUNTIME_FAILED_WHITELIST_CHECK);
 						}
 					}
 				}
@@ -404,18 +411,19 @@ namespace strange.framework.impl
 				binding = performKeyValueBindings (keyList, valueList);
 
 				// Optionally look for ToName
-				if (item.ContainsKey("ToName"))
+				if (item.ContainsKey ("ToName"))
 				{
-					binding = binding.ToName (item["ToName"]);
+					binding = binding.ToName (item ["ToName"]);
 				}
 
 				// Add runtime options
-				if (item.ContainsKey("Options"))
+				if (item.ContainsKey ("Options"))
 				{
-					List<object> optionsList = conformRuntimeToList(item["Options"]);
-					addRuntimeOptions(binding, optionsList);
+					List<object> optionsList = conformRuntimeToList (item ["Options"]);
+					addRuntimeOptions (binding, optionsList);
 				}
 			}
+			return binding;
 		}
 
 		virtual protected Dictionary<string, object> ConformRuntimeItem(Dictionary<string, object> dictionary)

--- a/StrangeIoC/scripts/strange/framework/impl/Binder.cs
+++ b/StrangeIoC/scripts/strange/framework/impl/Binder.cs
@@ -355,6 +355,7 @@ namespace strange.framework.impl
 			for (int a=0, aa=list.Count; a < aa; a++)
 			{
 				Dictionary<string, object> item = list[a] as Dictionary<string, object>;
+				item = ConformRuntimeItem (item);
 				List<object> keyList;
 				List<object> valueList;
 				IBinding binding = null;
@@ -415,6 +416,11 @@ namespace strange.framework.impl
 					addRuntimeOptions(binding, optionsList);
 				}
 			}
+		}
+
+		virtual protected Dictionary<string, object> ConformRuntimeItem(Dictionary<string, object> dictionary)
+		{
+			return dictionary;
 		}
 
 		virtual protected IBinding performKeyValueBindings(List<object> keyList, List<object> valueList)

--- a/StrangeIoC/scripts/strange/framework/impl/Binder.cs
+++ b/StrangeIoC/scripts/strange/framework/impl/Binder.cs
@@ -356,6 +356,13 @@ namespace strange.framework.impl
 			}
 		}
 
+		/// <summary>
+		/// Consumes an individual JSON element and returns the Binding that element represents 
+		/// </summary>
+		/// <returns>The Binding represented the provided JSON</returns>
+		/// <param name="item">A Dictionary of definitions for the individual binding parameters</param>
+		/// <param name="testBinding">An example binding for the current Binder. This method uses the 
+		/// binding constraints of the example to raise errors if asked to parse illegally</param>
 		virtual protected IBinding ConsumeItem(Dictionary<string, object> item, IBinding testBinding)
 		{
 			int bindConstraints = (testBinding.keyConstraint == BindingConstraintType.ONE) ? 0 : 1;
@@ -426,11 +433,25 @@ namespace strange.framework.impl
 			return binding;
 		}
 
+		/// <summary>
+		/// Override this method in subclasses to add special-case SYNTACTICAL SUGAR for Runtime JSON bindings.
+		/// For example, if your Binder needs a special JSON tag BindView, such that BindView is simply
+		/// another way of expressing 'Bind', override this method conform the sugar to
+		/// match the base definition (BindView becomes Bind).
+		/// </summary>
+		/// <returns>The conformed Dictionary.</returns>
+		/// <param name="dictionary">A Dictionary representing the options for a Binding.</param>
 		virtual protected Dictionary<string, object> ConformRuntimeItem(Dictionary<string, object> dictionary)
 		{
 			return dictionary;
 		}
 
+		/// <summary>
+		/// Performs the key value bindings for a JSON runtime binding.
+		/// </summary>
+		/// <returns>A Binding.</returns>
+		/// <param name="keyList">A list of things to Bind.</param>
+		/// <param name="valueList">A list of the things to which we're binding.</param>
 		virtual protected IBinding performKeyValueBindings(List<object> keyList, List<object> valueList)
 		{
 			IBinding binding = null;
@@ -448,7 +469,16 @@ namespace strange.framework.impl
 			return binding;
 		}
 
-		/// Default options: Weak
+		/// <summary>
+		/// Override this method to decorate subclasses with further runtime capabilities.
+		/// For example, InjectionBinder adds ToSingleton and CrossContext capabilities so that
+		/// these can be specified in JSON.
+		/// 
+		/// By default, the Binder supports 'Weak' as a runtime option.
+		/// </summary>
+		/// <returns>The provided Binding.</returns>
+		/// <param name="binding">A Binding to have capabilities added.</param>
+		/// <param name="options">The list of runtime options for this Binding.</param>
 		virtual protected IBinding addRuntimeOptions(IBinding binding, List<object> options)
 		{
 			if (options.IndexOf ("Weak") > -1)


### PR DESCRIPTION
Creates an AbstractMediationBinder, abstracting non-MonoBehaviour aspects out of the MediationBinder. This allows a measure of Unit Testing in previsously untestable code, and makes it possible for MediationBinder and the upcoming EditorMediationBinder to be DRYer and more flexible.