### PR TITLE
Fix alloc issues and tabify signals

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignal.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/signal/TestSignal.cs
@@ -1,144 +1,159 @@
 ﻿using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using strange.extensions.signal.api;
 using strange.extensions.signal.impl;
 
 namespace strange.unittests
 {
-    [TestFixture()]
-    public class TestSignal
-    {
+	[TestFixture()]
+	public class TestSignal
+	{
 
-        [SetUp]
-        public void SetUp()
-        {
-            testValue = 0;
-        }
+		[SetUp]
+		public void SetUp()
+		{
+			testValue = 0;
+		}
 
-        private int testValue = 0;
-        private int testInt = 1;
-        private int testIntTwo = 2;
-        private int testIntThree = 3;
-        private int testIntFour = 4;
-        private int intToIncrement;
+		private int testValue = 0;
+		private int testInt = 1;
+		private int testIntTwo = 2;
+		private int testIntThree = 3;
+		private int testIntFour = 4;
+		private int intToIncrement;
+		private const int baseSignalValue = 1000;
 
-        [Test]
-        public void TestNoArgSignal()
-        {
-            Signal signal = new Signal();
+		[Test]
+		public void TestNoArgSignal()
+		{
+			Signal signal = new Signal();
 
-            signal.AddListener(NoArgSignalCallback);
-            signal.Dispatch();
-            Assert.AreEqual(1, testValue);
-        }
-        [Test]
-        public void TestOneArgSignal()
-        {
-            Signal<int> signal = new Signal<int>();
+			signal.AddListener(NoArgSignalCallback);
+			signal.Dispatch();
+			Assert.AreEqual(1, testValue);
+		}
+		[Test]
+		public void TestOneArgSignal()
+		{
+			Signal<int> signal = new Signal<int>();
 
-            signal.AddListener(OneArgSignalCallback);
-            signal.Dispatch(testInt);
-            Assert.AreEqual(testInt, testValue);
-        }
+			signal.AddListener(OneArgSignalCallback);
+			signal.Dispatch(testInt);
+			Assert.AreEqual(testInt, testValue);
+		}
 
-        //These are testing base functions, but also that ordering is correct using mathematical operators
-        [Test]
-        public void TestTwoArgSignal()
-        {
-            Signal<int, int> signal = new Signal<int, int>();
+		//These are testing base functions, but also that ordering is correct using mathematical operators
+		[Test]
+		public void TestTwoArgSignal()
+		{
+			Signal<int, int> signal = new Signal<int, int>();
 
-            signal.AddListener(TwoArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo);
-            Assert.AreEqual(testInt + testIntTwo, testValue);
+			signal.AddListener(TwoArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo);
+			Assert.AreEqual(testInt + testIntTwo, testValue);
 
-            signal.RemoveListener(TwoArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo);
-            Assert.AreEqual(testInt + testIntTwo, testValue); //Removed listener should have no-op
+			signal.RemoveListener(TwoArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo);
+			Assert.AreEqual(testInt + testIntTwo, testValue); //Removed listener should have no-op
 
-            signal.AddOnce(TwoArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo);
-            Assert.AreEqual((testInt + testIntTwo) * 2, testValue);
+			signal.AddOnce(TwoArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo);
+			Assert.AreEqual((testInt + testIntTwo) * 2, testValue);
 
-            signal.Dispatch(testInt, testIntTwo);
-            Assert.AreEqual((testInt + testIntTwo) * 2, testValue); //addonce should result in no-op
+			signal.Dispatch(testInt, testIntTwo);
+			Assert.AreEqual((testInt + testIntTwo) * 2, testValue); //addonce should result in no-op
 
-        }
-        [Test]
-        public void TestThreeArgSignal()
-        {
-            Signal<int, int, int> signal = new Signal<int, int, int>();
+		}
+		[Test]
+		public void TestThreeArgSignal()
+		{
+			Signal<int, int, int> signal = new Signal<int, int, int>();
 
-            int intendedResult = (testInt + testIntTwo) * testIntThree;
-            signal.AddListener(ThreeArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo, testIntThree);
-            Assert.AreEqual(intendedResult, testValue);
+			int intendedResult = (testInt + testIntTwo) * testIntThree;
+			signal.AddListener(ThreeArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo, testIntThree);
+			Assert.AreEqual(intendedResult, testValue);
 
-            signal.RemoveListener(ThreeArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo, testIntThree);
-            Assert.AreEqual(intendedResult, testValue); //no-op due to remove
+			signal.RemoveListener(ThreeArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo, testIntThree);
+			Assert.AreEqual(intendedResult, testValue); //no-op due to remove
 
-            intendedResult += testInt;
-            intendedResult += testIntTwo;
-            intendedResult *= testIntThree;
+			intendedResult += testInt;
+			intendedResult += testIntTwo;
+			intendedResult *= testIntThree;
 
-            signal.AddOnce(ThreeArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo, testIntThree);
-            Assert.AreEqual(intendedResult, testValue);
+			signal.AddOnce(ThreeArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo, testIntThree);
+			Assert.AreEqual(intendedResult, testValue);
 
-            signal.Dispatch(testInt, testIntTwo, testIntThree);
-            Assert.AreEqual(intendedResult, testValue); //Add once should result in no-op
-        }
-        [Test]
-        public void TestFourArgSignal()
-        {
-            Signal<int, int, int, int> signal = new Signal<int, int, int, int>();
+			signal.Dispatch(testInt, testIntTwo, testIntThree);
+			Assert.AreEqual(intendedResult, testValue); //Add once should result in no-op
+		}
+		[Test]
+		public void TestFourArgSignal()
+		{
+			Signal<int, int, int, int> signal = new Signal<int, int, int, int>();
 
-            int intendedResult = ((testInt + testIntTwo) * testIntThree) - testIntFour;
-            signal.AddListener(FourArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
-            Assert.AreEqual(intendedResult, testValue);
+			int intendedResult = ((testInt + testIntTwo) * testIntThree) - testIntFour;
+			signal.AddListener(FourArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+			Assert.AreEqual(intendedResult, testValue);
 
-            signal.RemoveListener(FourArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
-            Assert.AreEqual(intendedResult, testValue); //no-op due to remove
+			signal.RemoveListener(FourArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+			Assert.AreEqual(intendedResult, testValue); //no-op due to remove
 
-            intendedResult += testInt;
-            intendedResult += testIntTwo;
-            intendedResult *= testIntThree;
-            intendedResult -= testIntFour;
+			intendedResult += testInt;
+			intendedResult += testIntTwo;
+			intendedResult *= testIntThree;
+			intendedResult -= testIntFour;
 
-            signal.AddOnce(FourArgSignalCallback);
-            signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
-            Assert.AreEqual(intendedResult, testValue);
+			signal.AddOnce(FourArgSignalCallback);
+			signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+			Assert.AreEqual(intendedResult, testValue);
 
-            signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
-            Assert.AreEqual(intendedResult, testValue); //Add once should result in no-op
-        }
-        [Test]
-        public void TestOnce()
-        {
-            Signal<int> signal = new Signal<int>();
+			signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+			Assert.AreEqual(intendedResult, testValue); //Add once should result in no-op
+		}
+		[Test]
+		public void TestOnce()
+		{
+			Signal<int> signal = new Signal<int>();
 
-            signal.AddOnce(OneArgSignalCallback);
-            signal.Dispatch(testInt);
-            Assert.AreEqual(testInt, testValue);
+			signal.AddOnce(OneArgSignalCallback);
+			signal.Dispatch(testInt);
+			Assert.AreEqual(testInt, testValue);
 
-            signal.Dispatch(testInt);
-            Assert.AreEqual(testInt, testValue); //should not fire a second time
-        }
+			signal.Dispatch(testInt);
+			Assert.AreEqual(testInt, testValue); //should not fire a second time
+		}
 
-        [Test]
-        public void TestMultipleCallbacks()
-        {
-            Signal<int> signal = new Signal<int>();
+		[Test]
+		public void TestBaseOnce()
+		{
+			BaseSignal signal = new BaseSignal();
+			signal.AddOnce(BaseSignalCallback);
+			
+			signal.Dispatch(new object[] {});
+			Assert.AreEqual(testValue, baseSignalValue);
 
-            signal.AddListener(OneArgSignalCallback);
-            signal.AddListener(OneArgSignalCallbackTwo);
+			signal.Dispatch(new object[] { });
+			Assert.AreEqual(testValue, baseSignalValue);
+		}
 
-            signal.Dispatch(testInt);
+		[Test]
+		public void TestMultipleCallbacks()
+		{
+			Signal<int> signal = new Signal<int>();
 
-            Assert.AreEqual(testInt + 1, testValue);
-        }
+			signal.AddListener(OneArgSignalCallback);
+			signal.AddListener(OneArgSignalCallbackTwo);
+
+			signal.Dispatch(testInt);
+
+			Assert.AreEqual(testInt + 1, testValue);
+		}
 
 		[Test]
 		public void TestRemoveListener()
@@ -173,9 +188,9 @@ namespace strange.unittests
 #region RemoveAllListeners
 
 		[Test]
-	    public void TestRemoveAllListeners()
-	    {
-		    Signal signal = new Signal();
+		public void TestRemoveAllListeners()
+		{
+			Signal signal = new Signal();
 
 			signal.AddListener(NoArgSignalCallback);
 			signal.AddListener(NoArgSignalCallbackTwo);
@@ -184,7 +199,7 @@ namespace strange.unittests
 			signal.Dispatch();
 
 			Assert.AreEqual(0, testValue);
-	    }
+		}
 		[Test]
 		public void TestRemoveAllListenersOne()
 		{
@@ -238,10 +253,10 @@ namespace strange.unittests
 			Assert.AreEqual(0, testValue);
 		}
 
-	    [Test]
-	    public void TestRemoveAllRemovesOnce()
-	    {
-		    Signal signal = new Signal();
+		[Test]
+		public void TestRemoveAllRemovesOnce()
+		{
+			Signal signal = new Signal();
 			signal.AddOnce(NoArgSignalCallback);
 			signal.AddOnce(NoArgSignalCallbackTwo);
 
@@ -249,210 +264,241 @@ namespace strange.unittests
 			signal.Dispatch();
 
 			Assert.AreEqual(0, testValue);
-	    }
+		}
+
+		[Test]
+		public void TestRemoveListenerDoesntBlowUp()
+		{
+			Signal signal = new Signal();
+			signal.RemoveListener(NoArgSignalCallback);
+		}
+		[Test]
+		public void TestRemoveListenerDoesntBlowUpOne()
+		{
+			Signal<int> signal = new Signal<int>();
+			signal.RemoveListener(OneArgSignalCallback);
+		}
+		[Test]
+		public void TestRemoveListenerDoesntBlowUpTwo()
+		{
+			Signal<int,int> signal = new Signal<int,int>();
+			signal.RemoveListener(TwoArgSignalCallback);
+		}
+		[Test]
+		public void TestRemoveListenerDoesntBlowUpThree()
+		{
+			Signal<int,int,int> signal = new Signal<int,int,int>();
+			signal.RemoveListener(ThreeArgSignalCallback);
+		}
+		[Test]
+		public void TestRemoveListenerDoesntBlowUpFour()
+		{
+			Signal<int,int,int,int> signal = new Signal<int,int,int,int>();
+			signal.RemoveListener(FourArgSignalCallback);
+		}
 
 #endregion
 
 #region GetTypes
 
 		[Test]
-        public void GetTypes_ThreeType_ExpectsTypesReturnedInList()
-        {
-            Signal<int, string, float> signal = new Signal<int, string, float>();
+		public void GetTypes_ThreeType_ExpectsTypesReturnedInList()
+		{
+			Signal<int, string, float> signal = new Signal<int, string, float>();
 
-            var actual = signal.GetTypes();
+			var actual = signal.GetTypes();
 
-            var expected = this.GetThreeExpectedTypes();
-            Assert.AreEqual(expected, actual);
-        }
+			var expected = this.GetThreeExpectedTypes();
+			Assert.AreEqual(expected, actual);
+		}
 
-        private IList<Type> GetThreeExpectedTypes()
-        {
-            var expected = new List<Type>();
-            expected.Add(typeof(int));
-            expected.Add(typeof(string));
-            expected.Add(typeof(float));
-            return expected;
-        }
+		private IList<Type> GetThreeExpectedTypes()
+		{
+			var expected = new List<Type>();
+			expected.Add(typeof(int));
+			expected.Add(typeof(string));
+			expected.Add(typeof(float));
+			return expected;
+		}
 
-        [Test]
-        public void GetTypes_FourType_ExpectsTypesReturnedInList()
-        {
-            Signal<int, string, float, Signal> signal = new Signal<int, string, float, Signal>();
+		[Test]
+		public void GetTypes_FourType_ExpectsTypesReturnedInList()
+		{
+			Signal<int, string, float, Signal> signal = new Signal<int, string, float, Signal>();
 
-            var actual = signal.GetTypes();
+			var actual = signal.GetTypes();
 
-            var expected = this.GetThreeExpectedTypes();
-            expected.Add(typeof(Signal));
-            Assert.AreEqual(expected, actual);
-        }
+			var expected = this.GetThreeExpectedTypes();
+			expected.Add(typeof(Signal));
+			Assert.AreEqual(expected, actual);
+		}
 #endregion
 
 #region NoCallbackDuplication
 		[Test]
-        public void AddListener_SignalWithNoTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal signal = new Signal();
-            intToIncrement = 0;
-            signal.AddListener(SimpleSignalCallback);
-            signal.AddListener(SimpleSignalCallback);
+		public void AddListener_SignalWithNoTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal signal = new Signal();
+			intToIncrement = 0;
+			signal.AddListener(SimpleSignalCallback);
+			signal.AddListener(SimpleSignalCallback);
 
-            signal.Dispatch();
+			signal.Dispatch();
 
-            Assert.AreEqual(1, intToIncrement);
-        }
+			Assert.AreEqual(1, intToIncrement);
+		}
 
-        [Test]
-        public void AddOnce_SignalWithNoTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal signal = new Signal();
-            intToIncrement = 0;
-            signal.AddOnce(SimpleSignalCallback);
-            signal.AddOnce(SimpleSignalCallback);
+		[Test]
+		public void AddOnce_SignalWithNoTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal signal = new Signal();
+			intToIncrement = 0;
+			signal.AddOnce(SimpleSignalCallback);
+			signal.AddOnce(SimpleSignalCallback);
 
-            signal.Dispatch();
+			signal.Dispatch();
 
-            Assert.AreEqual(1, intToIncrement);
-        }
+			Assert.AreEqual(1, intToIncrement);
+		}
 
-        [Test]
-        public void AddListener_SignalWithOneTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal<int> signal = new Signal<int>();
-            testInt = 42;
-            signal.AddListener(OneArgSignalCallback);
-            signal.AddListener(OneArgSignalCallback);
+		[Test]
+		public void AddListener_SignalWithOneTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal<int> signal = new Signal<int>();
+			testInt = 42;
+			signal.AddListener(OneArgSignalCallback);
+			signal.AddListener(OneArgSignalCallback);
 
-            signal.Dispatch(testInt);
+			signal.Dispatch(testInt);
 
-            Assert.AreEqual(testInt, testValue);
-        }
+			Assert.AreEqual(testInt, testValue);
+		}
 
-        [Test]
-        public void AddOnce_SignalWithOneTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal<int> signal = new Signal<int>();
-            testInt = 42;
-            signal.AddOnce(OneArgSignalCallback);
-            signal.AddOnce(OneArgSignalCallback);
+		[Test]
+		public void AddOnce_SignalWithOneTypeGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal<int> signal = new Signal<int>();
+			testInt = 42;
+			signal.AddOnce(OneArgSignalCallback);
+			signal.AddOnce(OneArgSignalCallback);
 
-            signal.Dispatch(testInt);
+			signal.Dispatch(testInt);
 
-            Assert.AreEqual(testInt, testValue);
-        }
+			Assert.AreEqual(testInt, testValue);
+		}
 
-        [Test]
-        public void AddListener_SignalWithTwoTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal<int, int> signal = new Signal<int, int>();
-            this.CreateTwoInts();
-            signal.AddListener(TwoArgCallback);
-            signal.AddListener(TwoArgCallback);
+		[Test]
+		public void AddListener_SignalWithTwoTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal<int, int> signal = new Signal<int, int>();
+			this.CreateTwoInts();
+			signal.AddListener(TwoArgCallback);
+			signal.AddListener(TwoArgCallback);
 
-            signal.Dispatch(testInt, testIntTwo);
+			signal.Dispatch(testInt, testIntTwo);
 
-            int expected = this.GetTwoIntExpected();
-            Assert.AreEqual(expected, this.testValue);
-        }
+			int expected = this.GetTwoIntExpected();
+			Assert.AreEqual(expected, this.testValue);
+		}
 
-        [Test]
-        public void AddOnce_SignalWithTwoTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal<int, int> signal = new Signal<int, int>();
-            this.CreateTwoInts();
-            signal.AddOnce(TwoArgCallback);
-            signal.AddOnce(TwoArgCallback);
+		[Test]
+		public void AddOnce_SignalWithTwoTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal<int, int> signal = new Signal<int, int>();
+			this.CreateTwoInts();
+			signal.AddOnce(TwoArgCallback);
+			signal.AddOnce(TwoArgCallback);
 
-            signal.Dispatch(testInt, testIntTwo);
+			signal.Dispatch(testInt, testIntTwo);
 
-            int expected = this.GetTwoIntExpected();
-            Assert.AreEqual(expected, this.testValue);
-        }
+			int expected = this.GetTwoIntExpected();
+			Assert.AreEqual(expected, this.testValue);
+		}
 
-        [Test]
-        public void AddListener_SignalWithThreeTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal<int, int, int> signal = new Signal<int, int, int>();
-            this.CreateThreeInts();
-            signal.AddListener(ThreeArgCallback);
-            signal.AddListener(ThreeArgCallback);
+		[Test]
+		public void AddListener_SignalWithThreeTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal<int, int, int> signal = new Signal<int, int, int>();
+			this.CreateThreeInts();
+			signal.AddListener(ThreeArgCallback);
+			signal.AddListener(ThreeArgCallback);
 
-            signal.Dispatch(testInt, testIntTwo, testIntThree);
+			signal.Dispatch(testInt, testIntTwo, testIntThree);
 
-            int expected = this.GetThreeIntExpected();
-            Assert.AreEqual(expected, this.testValue);
-        }
+			int expected = this.GetThreeIntExpected();
+			Assert.AreEqual(expected, this.testValue);
+		}
 
-        [Test]
-        public void AddOnce_SignalWithThreeTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal<int, int, int> signal = new Signal<int, int, int>();
-            this.CreateThreeInts();
-            signal.AddOnce(ThreeArgCallback);
-            signal.AddOnce(ThreeArgCallback);
+		[Test]
+		public void AddOnce_SignalWithThreeTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal<int, int, int> signal = new Signal<int, int, int>();
+			this.CreateThreeInts();
+			signal.AddOnce(ThreeArgCallback);
+			signal.AddOnce(ThreeArgCallback);
 
-            signal.Dispatch(testInt, testIntTwo, testIntThree);
+			signal.Dispatch(testInt, testIntTwo, testIntThree);
 
-            int expected = this.GetThreeIntExpected();
-            Assert.AreEqual(expected, this.testValue);
-        }
+			int expected = this.GetThreeIntExpected();
+			Assert.AreEqual(expected, this.testValue);
+		}
 
-        [Test]
-        public void AddListener_SignalWithFourTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal<int, int, int, int> signal = new Signal<int, int, int, int>();
-            this.CreateFourInts();
-            signal.AddListener(FourArgCallback);
-            signal.AddListener(FourArgCallback);
+		[Test]
+		public void AddListener_SignalWithFourTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal<int, int, int, int> signal = new Signal<int, int, int, int>();
+			this.CreateFourInts();
+			signal.AddListener(FourArgCallback);
+			signal.AddListener(FourArgCallback);
 
-            signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+			signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
 
-            int expected = this.GetFourIntExpected();
-            Assert.AreEqual(expected, this.testValue);
-        }
+			int expected = this.GetFourIntExpected();
+			Assert.AreEqual(expected, this.testValue);
+		}
 
-        [Test]
-        public void AddOnce_SignalWithFourTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
-        {
-            Signal<int, int, int, int> signal = new Signal<int, int, int, int>();
-            this.CreateFourInts();
-            signal.AddOnce(FourArgCallback);
-            signal.AddOnce(FourArgCallback);
+		[Test]
+		public void AddOnce_SignalWithFourTypesGivenSameCallbackMultipleTimes_ExpectsDelegateCalledOnlyOnce()
+		{
+			Signal<int, int, int, int> signal = new Signal<int, int, int, int>();
+			this.CreateFourInts();
+			signal.AddOnce(FourArgCallback);
+			signal.AddOnce(FourArgCallback);
 
-            signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
+			signal.Dispatch(testInt, testIntTwo, testIntThree, testIntFour);
 
-            int expected = this.GetFourIntExpected();
-            Assert.AreEqual(expected, this.testValue);
-        }
+			int expected = this.GetFourIntExpected();
+			Assert.AreEqual(expected, this.testValue);
+		}
 
 #endregion
 
 #region callback
 
 		private void NoArgSignalCallback()
-        {
-            testValue++;
-        }
+		{
+			testValue++;
+		}
 
-	    private void NoArgSignalCallbackTwo()
-	    {
-		    testValue += 10;
-	    }
+		private void NoArgSignalCallbackTwo()
+		{
+			testValue += 10;
+		}
 
-        private void OneArgSignalCallback(int argInt)
-        {
-            testValue += argInt;
-        }
+		private void OneArgSignalCallback(int argInt)
+		{
+			testValue += argInt;
+		}
 
-        private void OneArgSignalCallbackTwo(int argInt)
-        {
-            testValue++;
-        }
-        private void TwoArgSignalCallback(int one, int two)
-        {
-            testValue += one;
-            testValue += two;
-        }
+		private void OneArgSignalCallbackTwo(int argInt)
+		{
+			testValue++;
+		}
+		private void TwoArgSignalCallback(int one, int two)
+		{
+			testValue += one;
+			testValue += two;
+		}
 
 		private void TwoArgSignalCallbackTwo(int one, int two)
 		{
@@ -460,12 +506,12 @@ namespace strange.unittests
 			testValue *= two;
 		}
 
-        private void ThreeArgSignalCallback(int one, int two, int three)
-        {
-            testValue += one;
-            testValue += two;
-            testValue *= three;
-        }
+		private void ThreeArgSignalCallback(int one, int two, int three)
+		{
+			testValue += one;
+			testValue += two;
+			testValue *= three;
+		}
 		private void ThreeArgSignalCallbackTwo(int one, int two, int three)
 		{
 			testValue *= one;
@@ -473,13 +519,13 @@ namespace strange.unittests
 			testValue *= three;
 		}
 
-        private void FourArgSignalCallback(int one, int two, int three, int four)
-        {
-            testValue += one;
-            testValue += two;
-            testValue *= three;
-            testValue -= four;
-        }
+		private void FourArgSignalCallback(int one, int two, int three, int four)
+		{
+			testValue += one;
+			testValue += two;
+			testValue *= three;
+			testValue -= four;
+		}
 		private void FourArgSignalCallbackTwo(int one, int two, int three, int four)
 		{
 			testValue *= one;
@@ -545,7 +591,13 @@ namespace strange.unittests
 		{
 			this.testValue += arg1 + arg2 + arg3 + arg4;
 		}
-#endregion
+
+		private void BaseSignalCallback(IBaseSignal signal, object[] args)
+		{
+			testValue += baseSignalValue;
+		}
+
+		#endregion
 
 
 	}

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/BaseSignal.cs
@@ -26,56 +26,59 @@
 using System;
 using strange.extensions.signal.api;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace strange.extensions.signal.impl
 {
 	public class BaseSignal : IBaseSignal
 	{
-        
+		
 		/// The delegate for repeating listeners
-		public event Action<IBaseSignal, object[]> BaseListener = delegate { };
+		public event Action<IBaseSignal, object[]> BaseListener = null;
 
 		/// The delegate for one-off listeners
-		public event Action<IBaseSignal, object[]> OnceBaseListener = delegate { };
+		public event Action<IBaseSignal, object[]> OnceBaseListener = null;
 
 		public void Dispatch(object[] args) 
 		{ 
-			BaseListener(this, args);
-			OnceBaseListener(this, args);
-			OnceBaseListener = delegate { };
+			if (BaseListener != null)
+				BaseListener(this, args);
+			if (OnceBaseListener != null)
+				OnceBaseListener(this, args);
+			OnceBaseListener = null;
 		}
 
 		public virtual List<Type> GetTypes() { return new List<Type>(); }
 
-		public void AddListener(Action<IBaseSignal, object[]> callback) 
+		public void AddListener(Action<IBaseSignal, object[]> callback)
 		{
-			foreach (Delegate del in BaseListener.GetInvocationList())
-			{
-				Action<IBaseSignal, object[]> action = (Action<IBaseSignal, object[]>)del;
-				if (callback.Equals(action)) //If this callback exists already, ignore this addlistener
-					return;
-			}
-
-			BaseListener += callback;
+			BaseListener = AddUnique(BaseListener, callback);
 		}
 
 		public void AddOnce(Action<IBaseSignal, object[]> callback)
 		{
-			foreach (Delegate del in OnceBaseListener.GetInvocationList())
-			{
-				Action<IBaseSignal, object[]> action = (Action<IBaseSignal, object[]>)del;
-				if (callback.Equals(action)) //If this callback exists already, ignore this addlistener
-					return;
-			}
-
-			OnceBaseListener += callback;
+			OnceBaseListener = AddUnique(OnceBaseListener, callback);
 		}
 
-		public void RemoveListener(Action<IBaseSignal, object[]> callback) { BaseListener -= callback; }
+		private Action<T, U> AddUnique<T,U>(Action<T, U> listeners, Action<T, U> callback)
+		{
+			if (listeners == null || !listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
+
+		public void RemoveListener(Action<IBaseSignal, object[]> callback)
+		{
+			if (BaseListener != null)
+				BaseListener -= callback;
+		}
 
 		public virtual void RemoveAllListeners()
 		{
-			BaseListener = delegate { };
+			BaseListener = null;
+			OnceBaseListener = null;
 		}
 	   
 	}

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/Signal.cs
@@ -46,8 +46,8 @@
 
 		//SIGNAL WITH PARAMETERS
 		//Create a new signal with two parameters
- 		Signal<int, string> signal = new Signal<int, string>();
- 		//Add a listener
+		Signal<int, string> signal = new Signal<int, string>();
+		//Add a listener
 		signal.AddListener(callbackWithParamsIntAndString);
 		//Add a listener for the duration of precisely one Dispatch
 		signal.AddOnce(anotherCallbackWithParamsIntAndString);
@@ -70,259 +70,290 @@ using System.Linq;
 
 namespace strange.extensions.signal.impl
 {
-    public interface ISignal
-    {
-        Delegate listener { get; set; }
-	    void RemoveAllListeners();
-    }
-    /// Base concrete form for a Signal with no parameters
-    public class Signal : BaseSignal, ISignal
-    {
-        public event Action Listener = delegate { };
-        public event Action OnceListener = delegate { };
+	public interface ISignal
+	{
+		Delegate listener { get; set; }
+		void RemoveAllListeners();
+	}
+	/// Base concrete form for a Signal with no parameters
+	public class Signal : BaseSignal, ISignal
+	{
+		public event Action Listener = null;
+		public event Action OnceListener = null;
 
-        public void AddListener(Action callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
+		public void AddListener(Action callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
 
-        public void AddOnce(Action callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
-        public void RemoveListener(Action callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            return new List<Type>();
-        }
-        public void Dispatch()
-        {
-            Listener();
-            OnceListener();
-            OnceListener = delegate { };
-            base.Dispatch(null);
-        }
+		public void AddOnce(Action callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
 
-        private Action AddUnique(Action listeners, Action callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
+		public void RemoveListener(Action callback)
+		{
+			if (Listener != null)
+				Listener -= callback;
+		}
+		public override List<Type> GetTypes()
+		{
+			return new List<Type>();
+		}
+		public void Dispatch()
+		{
+			if (Listener != null)
+				Listener();
+			if (OnceListener != null)
+				OnceListener();
+			OnceListener = null;
+			base.Dispatch(null);
+		}
 
-	    public override void RemoveAllListeners()
-	    {
-			Listener = delegate { };
-		    OnceListener = delegate { };
-		    base.RemoveAllListeners();
-	    }
-
-        public Delegate listener { get { return Listener; } set { Listener = (Action) value; }}
-    }
-
-    /// Base concrete form for a Signal with one parameter
-    public class Signal<T> : BaseSignal, ISignal
-    {
-        public event Action<T> Listener = delegate { };
-        public event Action<T> OnceListener = delegate { };
-
-        public void AddListener(Action<T> callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
-
-        public void AddOnce(Action<T> callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
-
-        public void RemoveListener(Action<T> callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            List<Type> retv = new List<Type>();
-            retv.Add(typeof(T));
-            return retv;
-        }
-        public void Dispatch(T type1)
-        {
-            Listener(type1);
-            OnceListener(type1);
-            OnceListener = delegate { };
-            object[] outv = { type1 };
-            base.Dispatch(outv);
-        }
-
-        private Action<T> AddUnique(Action<T> listeners, Action<T> callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
+		private Action AddUnique(Action listeners, Action callback)
+		{
+			if (listeners == null || !listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
 
 		public override void RemoveAllListeners()
 		{
-			Listener = delegate { };
-			OnceListener = delegate { };
+			Listener = null;
+			OnceListener = null;
 			base.RemoveAllListeners();
 		}
 
-        public Delegate listener { get { return Listener; } set { Listener = (Action<T>) value; } }
-    }
+		public Delegate listener { get { return Listener; } set { Listener = (Action) value; }}
+	}
 
-    /// Base concrete form for a Signal with two parameters
-    public class Signal<T, U> : BaseSignal, ISignal
-    {
-        public event Action<T, U> Listener = delegate { };
-        public event Action<T, U> OnceListener = delegate { };
+	/// Base concrete form for a Signal with one parameter
+	public class Signal<T> : BaseSignal, ISignal
+	{
+		public event Action<T> Listener = null;
+		public event Action<T> OnceListener = null;
 
-        public void AddListener(Action<T, U> callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
+		public void AddListener(Action<T> callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
 
-        public void AddOnce(Action<T, U> callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
+		public void AddOnce(Action<T> callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
 
-        public void RemoveListener(Action<T, U> callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            List<Type> retv = new List<Type>();
-            retv.Add(typeof(T));
-            retv.Add(typeof(U));
-            return retv;
-        }
-        public void Dispatch(T type1, U type2)
-        {
-            Listener(type1, type2);
-            OnceListener(type1, type2);
-            OnceListener = delegate { };
-            object[] outv = { type1, type2 };
-            base.Dispatch(outv);
-        }
-        private Action<T, U> AddUnique(Action<T, U> listeners, Action<T, U> callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
+		public void RemoveListener(Action<T> callback)
+		{
+			if (Listener != null)
+				Listener -= callback;
+		}
+		public override List<Type> GetTypes()
+		{
+			List<Type> retv = new List<Type>();
+			retv.Add(typeof(T));
+			return retv;
+		}
+		public void Dispatch(T type1)
+		{
+			if (Listener != null)
+				Listener(type1);
+			if (OnceListener != null)
+				OnceListener(type1);
+			OnceListener = null;
+			object[] outv = { type1 };
+			base.Dispatch(outv);
+		}
+
+		private Action<T> AddUnique(Action<T> listeners, Action<T> callback)
+		{
+			if (listeners == null || !listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
 
 		public override void RemoveAllListeners()
 		{
-			Listener = delegate { };
-			OnceListener = delegate { };
+			Listener = null;
+			OnceListener = null;
 			base.RemoveAllListeners();
 		}
-        public Delegate listener { get { return Listener; } set { Listener = (Action<T, U>) value; } }
-    }
 
-    /// Base concrete form for a Signal with three parameters
-    public class Signal<T, U, V> : BaseSignal, ISignal
-    {
-        public event Action<T, U, V> Listener = delegate { };
-        public event Action<T, U, V> OnceListener = delegate { };
+		public Delegate listener { get { return Listener; } set { Listener = (Action<T>) value; } }
+	}
 
-        public void AddListener(Action<T, U, V> callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
+	/// Base concrete form for a Signal with two parameters
+	public class Signal<T, U> : BaseSignal, ISignal
+	{
+		public event Action<T, U> Listener = null;
+		public event Action<T, U> OnceListener = null;
 
-        public void AddOnce(Action<T, U, V> callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
+		public void AddListener(Action<T, U> callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
 
-        public void RemoveListener(Action<T, U, V> callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            List<Type> retv = new List<Type>();
-            retv.Add(typeof(T));
-            retv.Add(typeof(U));
-            retv.Add(typeof(V));
-            return retv;
-        }
-        public void Dispatch(T type1, U type2, V type3)
-        {
-            Listener(type1, type2, type3);
-            OnceListener(type1, type2, type3);
-            OnceListener = delegate { };
-            object[] outv = { type1, type2, type3 };
-            base.Dispatch(outv);
-        }
-        private Action<T, U, V> AddUnique(Action<T, U, V> listeners, Action<T, U, V> callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
+		public void AddOnce(Action<T, U> callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
+
+		public void RemoveListener(Action<T, U> callback)
+		{
+			if (Listener != null)
+				Listener -= callback;
+		}
+		public override List<Type> GetTypes()
+		{
+			List<Type> retv = new List<Type>();
+			retv.Add(typeof(T));
+			retv.Add(typeof(U));
+			return retv;
+		}
+		public void Dispatch(T type1, U type2)
+		{
+			if (Listener != null)
+				Listener(type1, type2);
+			if (OnceListener != null)
+				OnceListener(type1, type2);
+			OnceListener = null;
+			object[] outv = { type1, type2 };
+			base.Dispatch(outv);
+		}
+		private Action<T, U> AddUnique(Action<T, U> listeners, Action<T, U> callback)
+		{
+			if (listeners == null || !listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
+
 		public override void RemoveAllListeners()
 		{
-			Listener = delegate { };
-			OnceListener = delegate { };
+			Listener = null;
+			OnceListener = null;
 			base.RemoveAllListeners();
 		}
-        public Delegate listener { get { return Listener; } set { Listener = (Action<T, U, V>) value; } }
-    }
+		public Delegate listener { get { return Listener; } set { Listener = (Action<T, U>) value; } }
+	}
 
-    /// Base concrete form for a Signal with four parameters
-    public class Signal<T, U, V, W> : BaseSignal, ISignal
-    {
-        public event Action<T, U, V, W> Listener = delegate { };
-        public event Action<T, U, V, W> OnceListener = delegate { };
+	/// Base concrete form for a Signal with three parameters
+	public class Signal<T, U, V> : BaseSignal, ISignal
+	{
+		public event Action<T, U, V> Listener = null;
+		public event Action<T, U, V> OnceListener = null;
 
-        public void AddListener(Action<T, U, V, W> callback)
-        {
-            Listener = this.AddUnique(Listener, callback);
-        }
+		public void AddListener(Action<T, U, V> callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
 
-        public void AddOnce(Action<T, U, V, W> callback)
-        {
-            OnceListener = this.AddUnique(OnceListener, callback);
-        }
+		public void AddOnce(Action<T, U, V> callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
 
-        public void RemoveListener(Action<T, U, V, W> callback) { Listener -= callback; }
-        public override List<Type> GetTypes()
-        {
-            List<Type> retv = new List<Type>();
-            retv.Add(typeof(T));
-            retv.Add(typeof(U));
-            retv.Add(typeof(V));
-            retv.Add(typeof(W));
-            return retv;
-        }
-        public void Dispatch(T type1, U type2, V type3, W type4)
-        {
-            Listener(type1, type2, type3, type4);
-            OnceListener(type1, type2, type3, type4);
-            OnceListener = delegate { };
-            object[] outv = { type1, type2, type3, type4 };
-            base.Dispatch(outv);
-        }
-
-        private Action<T, U, V, W> AddUnique(Action<T, U, V, W> listeners, Action<T, U, V, W> callback)
-        {
-            if (!listeners.GetInvocationList().Contains(callback))
-            {
-                listeners += callback;
-            }
-            return listeners;
-        }
+		public void RemoveListener(Action<T, U, V> callback)
+		{
+			if (Listener != null)
+				Listener -= callback;
+		}
+		public override List<Type> GetTypes()
+		{
+			List<Type> retv = new List<Type>();
+			retv.Add(typeof(T));
+			retv.Add(typeof(U));
+			retv.Add(typeof(V));
+			return retv;
+		}
+		public void Dispatch(T type1, U type2, V type3)
+		{
+			if (Listener != null)
+				Listener(type1, type2, type3);
+			if (OnceListener != null)
+				OnceListener(type1, type2, type3);
+			OnceListener = null;
+			object[] outv = { type1, type2, type3 };
+			base.Dispatch(outv);
+		}
+		private Action<T, U, V> AddUnique(Action<T, U, V> listeners, Action<T, U, V> callback)
+		{
+			if (listeners == null || !listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
 		public override void RemoveAllListeners()
 		{
-			Listener = delegate { };
-			OnceListener = delegate { };
+			Listener = null;
+			OnceListener = null;
 			base.RemoveAllListeners();
 		}
-        public Delegate listener { get { return Listener; } set { Listener = (Action<T, U, V, W>) value; } }
-    }
+		public Delegate listener { get { return Listener; } set { Listener = (Action<T, U, V>) value; } }
+	}
+
+	/// Base concrete form for a Signal with four parameters
+	public class Signal<T, U, V, W> : BaseSignal, ISignal
+	{
+		public event Action<T, U, V, W> Listener = null;
+		public event Action<T, U, V, W> OnceListener = null;
+
+		public void AddListener(Action<T, U, V, W> callback)
+		{
+			Listener = this.AddUnique(Listener, callback);
+		}
+
+		public void AddOnce(Action<T, U, V, W> callback)
+		{
+			OnceListener = this.AddUnique(OnceListener, callback);
+		}
+
+		public void RemoveListener(Action<T, U, V, W> callback)
+		{
+			if (Listener != null)
+				Listener -= callback;
+		}
+		public override List<Type> GetTypes()
+		{
+			List<Type> retv = new List<Type>();
+			retv.Add(typeof(T));
+			retv.Add(typeof(U));
+			retv.Add(typeof(V));
+			retv.Add(typeof(W));
+			return retv;
+		}
+		public void Dispatch(T type1, U type2, V type3, W type4)
+		{
+			if (Listener != null)
+				Listener(type1, type2, type3, type4);
+			if (OnceListener != null)
+				OnceListener(type1, type2, type3, type4);
+			OnceListener = null;
+			object[] outv = { type1, type2, type3, type4 };
+			base.Dispatch(outv);
+		}
+
+		private Action<T, U, V, W> AddUnique(Action<T, U, V, W> listeners, Action<T, U, V, W> callback)
+		{
+			if (listeners == null || !listeners.GetInvocationList().Contains(callback))
+			{
+				listeners += callback;
+			}
+			return listeners;
+		}
+		public override void RemoveAllListeners()
+		{
+			Listener = null;
+			OnceListener = null;
+			base.RemoveAllListeners();
+		}
+		public Delegate listener { get { return Listener; } set { Listener = (Action<T, U, V, W>) value; } }
+	}
 
 }


### PR DESCRIPTION
Either merge this in to feature/signal-improvements, or if we've already merged that branch, we can create a new PR for this one.

This simply removes the default allocations for signals. I added a few more tests for coverage, and tabified everything.

use ?w=1 to see the diff w/o whitespace differences.