### PR TITLE
Add symlink to scripts for the examples project

### DIFF
--- a/StrangeIoC/examples/Assets/strange
+++ b/StrangeIoC/examples/Assets/strange
@@ -1,0 +1,1 @@
+../../scripts/strange


### PR DESCRIPTION
Related to #106 

The entire library is missing under the examples project. Adding a symlink (in osx) to the script folder seems to work correctly with Unity 5.0.1f1

``` sh
cd strangeioc
ln -s ../../scripts/strange  StrangeIoC/examples/Assets
```
