### PR TITLE
Allow for passing in an assembly if you need to for implicit bindings

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/implicitBind/api/IImplicitBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/implicitBind/api/IImplicitBinder.cs
@@ -14,18 +14,20 @@
  *		limitations under the License.
  */
 
+using System.Reflection;
 using strange.extensions.mediation.api;
 
 namespace strange.extensions.implicitBind.api
 {
 	public interface IImplicitBinder
 	{
-	    /// <summary>
-	    /// Search through indicated namespaces and scan for all annotated classes.
+		/// <summary>
+		/// Search through indicated namespaces and scan for all annotated classes.
 		/// Automatically create bindings.
-	    /// </summary>
-	    /// <param name="usingNamespaces">Array of namespaces. Compared using StartsWith. </param>
+		/// </summary>
+		/// <param name="usingNamespaces">Array of namespaces. Compared using StartsWith. </param>
 
-	    void ScanForAnnotatedClasses(string[] usingNamespaces);
+		void ScanForAnnotatedClasses(string[] usingNamespaces);
+		Assembly Assembly { get; set; }
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/implicitBind/impl/ImplicitBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/implicitBind/impl/ImplicitBinder.cs
@@ -37,13 +37,13 @@ namespace strange.extensions.implicitBind.impl
 
 
 		//Hold a copy of the assembly so we aren't retrieving this multiple times. 
-		private Assembly assembly;
+		public Assembly Assembly { get; set; }
 
 
 		[PostConstruct]
 		public void PostConstruct()
 		{
-			assembly = Assembly.GetExecutingAssembly();
+			Assembly = Assembly.GetExecutingAssembly();
 		}
 
 		/// <summary>
@@ -54,10 +54,10 @@ namespace strange.extensions.implicitBind.impl
 
 		public virtual void ScanForAnnotatedClasses(string[] usingNamespaces)
 		{
-			if (assembly != null)
+			if (Assembly != null)
 			{
 
-				IEnumerable<Type> types = assembly.GetExportedTypes();
+				IEnumerable<Type> types = Assembly.GetExportedTypes();
 
 				List<Type> typesInNamespaces = new List<Type>();
 				int namespacesLength = usingNamespaces.Length;


### PR DESCRIPTION
Due to the how we're gathering our assembly, if Strange is compiled to a dll (instead of used as source) implicit bindings will refer to the assembly.GetExecutingAssembly which will be the StrangeIoC assembly. This is, of course, wrong. This allows for manually overriding the assembly in this case.