### PR TITLE
Fix/unbind crosscontext

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/context/TestCrossContext.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/context/TestCrossContext.cs
@@ -6,233 +6,235 @@ using strange.extensions.injector.api;
 namespace strange.unittests
 {
 
-    /**
-     * Some functionality for Cross Context will be impossible to test
-     * The goal here is to test whatever we can, but the actual implementation will 
-     * vary per users and rely heavily on Unity in most cases, which we can't test here.
-     **/ 
+	/**
+	 * Some functionality for Cross Context will be impossible to test
+	 * The goal here is to test whatever we can, but the actual implementation will 
+	 * vary per users and rely heavily on Unity in most cases, which we can't test here.
+	 **/ 
 	[TestFixture]
 	public class TestCrossContext
 	{
-        object view;
-        CrossContext Parent;
-        CrossContext ChildOne;
-        CrossContext ChildTwo;
+		object view;
+		CrossContext Parent;
+		CrossContext ChildOne;
+		CrossContext ChildTwo;
 
-        [SetUp]
-        public void SetUp()
-        {
-            Context.firstContext = null;
-            view = new object();
-            Parent = new CrossContext(view, true);
-            ChildOne = new CrossContext(view, true); //Ctr will automatically add to Context.firstcontext. No need to call it manually (and you should not).
-            ChildTwo = new CrossContext(view, true);
-        }
-        
-        [Test]
-        public void TestValue()
-        {
-            TestModel parentModel = new TestModel();
-            Parent.injectionBinder.Bind<TestModel>().ToValue(parentModel).CrossContext(); //bind it once here and it should be accessible everywhere
+		[SetUp]
+		public void SetUp()
+		{
+			Context.firstContext = null;
+			view = new object();
+			Parent = new CrossContext(view, true);
+			ChildOne = new CrossContext(view, true); //Ctr will automatically add to Context.firstcontext. No need to call it manually (and you should not).
+			ChildTwo = new CrossContext(view, true);
+		}
+		
+		[Test]
+		public void TestValue()
+		{
+			TestModel parentModel = new TestModel();
+			Parent.injectionBinder.Bind<TestModel>().ToValue(parentModel).CrossContext(); //bind it once here and it should be accessible everywhere
 
-            TestModel parentModelTwo = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
+			TestModel parentModelTwo = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
 
-            Assert.AreSame(parentModel, parentModelTwo); //Assure that this value is correct
+			Assert.AreSame(parentModel, parentModelTwo); //Assure that this value is correct
 
-            TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childOneModel);
-            TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childTwoModel);
-            Assert.AreSame(childOneModel, childTwoModel); //These two should be the same object
+			TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childOneModel);
+			TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childTwoModel);
+			Assert.AreSame(childOneModel, childTwoModel); //These two should be the same object
 
-            Assert.AreEqual(0, parentModel.Value);
+			Assert.AreEqual(0, parentModel.Value);
 
-            parentModel.Value++;
-            Assert.AreEqual(1, childOneModel.Value);
+			parentModel.Value++;
+			Assert.AreEqual(1, childOneModel.Value);
 
-            parentModel.Value++;
-            Assert.AreEqual(2, childTwoModel.Value);
+			parentModel.Value++;
+			Assert.AreEqual(2, childTwoModel.Value);
 
-        }
+		}
 
-        [Test]
-        public void TestFactory()
-        {
-            TestModel parentModel = new TestModel();
-            Parent.injectionBinder.Bind<TestModel>().To<TestModel>().CrossContext();
+		[Test]
+		public void TestFactory()
+		{
+			TestModel parentModel = new TestModel();
+			Parent.injectionBinder.Bind<TestModel>().To<TestModel>().CrossContext();
 
-            TestModel parentModelTwo = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
+			TestModel parentModelTwo = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
 
-            Assert.AreNotSame(parentModel, parentModelTwo); //As it's a factory, we should not have the same objects
+			Assert.AreNotSame(parentModel, parentModelTwo); //As it's a factory, we should not have the same objects
 
-            TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childOneModel);
-            TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childTwoModel);
-            Assert.AreNotSame(childOneModel, childTwoModel); //These two should be DIFFERENT
+			TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childOneModel);
+			TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childTwoModel);
+			Assert.AreNotSame(childOneModel, childTwoModel); //These two should be DIFFERENT
 
-            Assert.AreEqual(0, parentModel.Value);
+			Assert.AreEqual(0, parentModel.Value);
 
-            parentModel.Value++;
-            Assert.AreEqual(0, childOneModel.Value); //doesn't change
+			parentModel.Value++;
+			Assert.AreEqual(0, childOneModel.Value); //doesn't change
 
-            parentModel.Value++;
-            Assert.AreEqual(0, childTwoModel.Value); //doesn't change
+			parentModel.Value++;
+			Assert.AreEqual(0, childTwoModel.Value); //doesn't change
 
-        }
+		}
 
-        [Test]
-        public void TestNamed()
-        {
-            string name = "Name";
-            TestModel parentModel = new TestModel();
-            Parent.injectionBinder.Bind<TestModel>().ToValue(parentModel).ToName(name).CrossContext(); //bind it once here and it should be accessible everywhere
+		[Test]
+		public void TestNamed()
+		{
+			string name = "Name";
+			TestModel parentModel = new TestModel();
+			Parent.injectionBinder.Bind<TestModel>().ToValue(parentModel).ToName(name).CrossContext(); //bind it once here and it should be accessible everywhere
 
-            TestModel parentModelTwo = Parent.injectionBinder.GetInstance<TestModel>(name) as TestModel;
+			TestModel parentModelTwo = Parent.injectionBinder.GetInstance<TestModel>(name) as TestModel;
 
-            Assert.AreSame(parentModel, parentModelTwo); //Assure that this value is correct
+			Assert.AreSame(parentModel, parentModelTwo); //Assure that this value is correct
 
-            TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>(name) as TestModel;
-            Assert.IsNotNull(childOneModel);
-            TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>(name) as TestModel;
-            Assert.IsNotNull(childTwoModel);
-            Assert.AreSame(childOneModel, childTwoModel); //These two should be the same object
+			TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>(name) as TestModel;
+			Assert.IsNotNull(childOneModel);
+			TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>(name) as TestModel;
+			Assert.IsNotNull(childTwoModel);
+			Assert.AreSame(childOneModel, childTwoModel); //These two should be the same object
 
-            Assert.AreEqual(0, parentModel.Value);
+			Assert.AreEqual(0, parentModel.Value);
 
-            parentModel.Value++;
-            Assert.AreEqual(1, childOneModel.Value);
+			parentModel.Value++;
+			Assert.AreEqual(1, childOneModel.Value);
 
-            parentModel.Value++;
-            Assert.AreEqual(2, childTwoModel.Value);
-        }
+			parentModel.Value++;
+			Assert.AreEqual(2, childTwoModel.Value);
+		}
 
-        //test that local bindings will override cross bindings
-        [Test]
-        public void TestLocalOverridesCrossContext()
-        {
-            Parent.injectionBinder.Bind<TestModel>().ToSingleton().CrossContext(); //bind the cross context binding.
-            TestModel initialChildOneModel = new TestModel();
-            initialChildOneModel.Value = 1000;
-
-
-            ChildOne.injectionBinder.Bind<TestModel>().ToValue(initialChildOneModel); //Bind a local override in this child
-
-            TestModel parentModel = Parent.injectionBinder.GetInstance<TestModel>() as TestModel; //Get the instance from the parent injector (The cross context binding)
+		//test that local bindings will override cross bindings
+		[Test]
+		public void TestLocalOverridesCrossContext()
+		{
+			Parent.injectionBinder.Bind<TestModel>().ToSingleton().CrossContext(); //bind the cross context binding.
+			TestModel initialChildOneModel = new TestModel();
+			initialChildOneModel.Value = 1000;
 
 
-            TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.AreSame(initialChildOneModel, childOneModel); // The value from getInstance is the same as the value we just mapped as a value locally
-            Assert.AreNotSame(childOneModel, parentModel); //The value from getinstance is NOT the same as the cross context value. We have overidden the cross context value locally
+			ChildOne.injectionBinder.Bind<TestModel>().ToValue(initialChildOneModel); //Bind a local override in this child
+
+			TestModel parentModel = Parent.injectionBinder.GetInstance<TestModel>() as TestModel; //Get the instance from the parent injector (The cross context binding)
 
 
-            TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childTwoModel);
-            Assert.AreNotSame(childOneModel, childTwoModel); //These two are different objects, the childTwoModel being cross context, and childone being the override
-            Assert.AreSame(parentModel, childTwoModel); //Both cross context models are the same
+			TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.AreSame(initialChildOneModel, childOneModel); // The value from getInstance is the same as the value we just mapped as a value locally
+			Assert.AreNotSame(childOneModel, parentModel); //The value from getinstance is NOT the same as the cross context value. We have overidden the cross context value locally
 
 
-            parentModel.Value++;
-            Assert.AreEqual(1, childTwoModel.Value); //cross context model should be changed
-
-            parentModel.Value++;
-            Assert.AreEqual(1000, childOneModel.Value); //local model is not changed
-
-
-            Assert.AreEqual(2, parentModel.Value); //cross context model is changed
-
-        }
-
-        [Test]
-        public void TestSingleton()
-        {
-            Parent.injectionBinder.Bind<TestModel>().ToSingleton().CrossContext(); //bind it once here and it should be accessible everywhere
-
-            TestModel parentModel = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(parentModel);
-
-            TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childOneModel);
-            TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childTwoModel);
-            
-            Assert.AreSame(parentModel, childOneModel); 
-            Assert.AreSame(parentModel, childTwoModel);
-            Assert.AreSame(childOneModel, childTwoModel);
-
-            IInjectionBinding binding = Parent.injectionBinder.GetBinding<TestModel>();
-            Assert.IsNotNull(binding);
-            Assert.IsTrue(binding.isCrossContext);
-
-            IInjectionBinding childBinding = ChildOne.injectionBinder.GetBinding<TestModel>();
-            Assert.IsNotNull(childBinding);
-            Assert.IsTrue(childBinding.isCrossContext);
+			TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childTwoModel);
+			Assert.AreNotSame(childOneModel, childTwoModel); //These two are different objects, the childTwoModel being cross context, and childone being the override
+			Assert.AreSame(parentModel, childTwoModel); //Both cross context models are the same
 
 
-            Assert.AreEqual(0, parentModel.Value);
+			parentModel.Value++;
+			Assert.AreEqual(1, childTwoModel.Value); //cross context model should be changed
 
-            parentModel.Value++;
-            Assert.AreEqual(1, childOneModel.Value);
-
-            parentModel.Value++;
-            Assert.AreEqual(2, childTwoModel.Value);
-
-        }
-
-        [Test]
-        public void TestSingletonUnbind()
-        {
-            Parent.injectionBinder.Bind<TestModel>().ToSingleton().CrossContext(); //bind it once here and it should be accessible everywhere
-
-            TestModel parentModel = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(parentModel);
-
-            TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childOneModel);
-            TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
-            Assert.IsNotNull(childTwoModel);
-
-            Assert.AreSame(parentModel, childOneModel);
-            Assert.AreSame(parentModel, childTwoModel);
-            Assert.AreSame(childOneModel, childTwoModel);
-
-            IInjectionBinding binding = Parent.injectionBinder.GetBinding<TestModel>();
-            Assert.IsNotNull(binding);
-            Assert.IsTrue(binding.isCrossContext);
-
-            IInjectionBinding childBinding = ChildOne.injectionBinder.GetBinding<TestModel>();
-            Assert.IsNotNull(childBinding);
-            Assert.IsTrue(childBinding.isCrossContext);
+			parentModel.Value++;
+			Assert.AreEqual(1000, childOneModel.Value); //local model is not changed
 
 
-            Assert.AreEqual(0, parentModel.Value);
+			Assert.AreEqual(2, parentModel.Value); //cross context model is changed
 
-            parentModel.Value++;
-            Assert.AreEqual(1, childOneModel.Value);
+		}
 
-            parentModel.Value++;
-            Assert.AreEqual(2, childTwoModel.Value);
+		[Test]
+		public void TestSingleton()
+		{
+			Parent.injectionBinder.Bind<TestModel>().ToSingleton().CrossContext(); //bind it once here and it should be accessible everywhere
+
+			TestModel parentModel = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(parentModel);
+
+			TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childOneModel);
+			TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childTwoModel);
+			
+			Assert.AreSame(parentModel, childOneModel); 
+			Assert.AreSame(parentModel, childTwoModel);
+			Assert.AreSame(childOneModel, childTwoModel);
+
+			IInjectionBinding binding = Parent.injectionBinder.GetBinding<TestModel>();
+			Assert.IsNotNull(binding);
+			Assert.IsTrue(binding.isCrossContext);
+
+			IInjectionBinding childBinding = ChildOne.injectionBinder.GetBinding<TestModel>();
+			Assert.IsNotNull(childBinding);
+			Assert.IsTrue(childBinding.isCrossContext);
 
 
+			Assert.AreEqual(0, parentModel.Value);
 
-            Parent.injectionBinder.Unbind<TestModel>();
+			parentModel.Value++;
+			Assert.AreEqual(1, childOneModel.Value);
 
-            binding = Parent.injectionBinder.GetBinding<TestModel>();
-            Assert.IsNull(binding);
+			parentModel.Value++;
+			Assert.AreEqual(2, childTwoModel.Value);
+
+		}
+
+		[Test]
+		public void TestSingletonUnbind()
+		{
+			Parent.injectionBinder.Bind<TestModel>().ToSingleton().CrossContext(); //bind it once here and it should be accessible everywhere
+
+			TestModel parentModel = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(parentModel);
+
+			TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childOneModel);
+			TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
+			Assert.IsNotNull(childTwoModel);
+
+			//Lots of lines that tell us they're all the same binding
+
+			Assert.AreSame(parentModel, childOneModel);
+			Assert.AreSame(parentModel, childTwoModel);
+			Assert.AreSame(childOneModel, childTwoModel);
+
+			IInjectionBinding binding = Parent.injectionBinder.GetBinding<TestModel>();
+			Assert.IsNotNull(binding);
+			Assert.IsTrue(binding.isCrossContext);
+
+			IInjectionBinding childBinding = ChildOne.injectionBinder.GetBinding<TestModel>();
+			Assert.IsNotNull(childBinding);
+			Assert.IsTrue(childBinding.isCrossContext);
 
 
-            childBinding = ChildOne.injectionBinder.GetBinding<TestModel>();
-            Assert.IsNull(childBinding);
-            childBinding = ChildTwo.injectionBinder.GetBinding<TestModel>();
-            Assert.IsNull(childBinding);
-        }
+			Assert.AreEqual(0, parentModel.Value);
+
+			parentModel.Value++;
+			Assert.AreEqual(1, childOneModel.Value);
+
+			parentModel.Value++;
+			Assert.AreEqual(2, childTwoModel.Value);
+
+			
+
+			//unbinding the parent should unbind the children who do not have a specific local binding
+
+			Parent.injectionBinder.Unbind<TestModel>();
+
+			binding = Parent.injectionBinder.GetBinding<TestModel>();
+			Assert.IsNull(binding);
+			childBinding = ChildOne.injectionBinder.GetBinding<TestModel>();
+			Assert.IsNull(childBinding);
+			childBinding = ChildTwo.injectionBinder.GetBinding<TestModel>();
+			Assert.IsNull(childBinding);
+		}
 
 	}
 
 
-    public class TestModel
-    {
-        public int Value = 0;
-    }
+	public class TestModel
+	{
+		public int Value = 0;
+	}
 
 }

--- a/StrangeIoC/scripts/strange/.tests/extensions/context/TestCrossContext.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/context/TestCrossContext.cs
@@ -179,6 +179,54 @@ namespace strange.unittests
 
         }
 
+        [Test]
+        public void TestSingletonUnbind()
+        {
+            Parent.injectionBinder.Bind<TestModel>().ToSingleton().CrossContext(); //bind it once here and it should be accessible everywhere
+
+            TestModel parentModel = Parent.injectionBinder.GetInstance<TestModel>() as TestModel;
+            Assert.IsNotNull(parentModel);
+
+            TestModel childOneModel = ChildOne.injectionBinder.GetInstance<TestModel>() as TestModel;
+            Assert.IsNotNull(childOneModel);
+            TestModel childTwoModel = ChildTwo.injectionBinder.GetInstance<TestModel>() as TestModel;
+            Assert.IsNotNull(childTwoModel);
+
+            Assert.AreSame(parentModel, childOneModel);
+            Assert.AreSame(parentModel, childTwoModel);
+            Assert.AreSame(childOneModel, childTwoModel);
+
+            IInjectionBinding binding = Parent.injectionBinder.GetBinding<TestModel>();
+            Assert.IsNotNull(binding);
+            Assert.IsTrue(binding.isCrossContext);
+
+            IInjectionBinding childBinding = ChildOne.injectionBinder.GetBinding<TestModel>();
+            Assert.IsNotNull(childBinding);
+            Assert.IsTrue(childBinding.isCrossContext);
+
+
+            Assert.AreEqual(0, parentModel.Value);
+
+            parentModel.Value++;
+            Assert.AreEqual(1, childOneModel.Value);
+
+            parentModel.Value++;
+            Assert.AreEqual(2, childTwoModel.Value);
+
+
+
+            Parent.injectionBinder.Unbind<TestModel>();
+
+            binding = Parent.injectionBinder.GetBinding<TestModel>();
+            Assert.IsNull(binding);
+
+
+            childBinding = ChildOne.injectionBinder.GetBinding<TestModel>();
+            Assert.IsNull(childBinding);
+            childBinding = ChildTwo.injectionBinder.GetBinding<TestModel>();
+            Assert.IsNull(childBinding);
+        }
+
 	}
 
 

--- a/StrangeIoC/scripts/strange/.tests/extensions/injector/TestImplicitBinding.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/injector/TestImplicitBinding.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using strange.extensions.context.impl;
 using strange.extensions.injector.impl;
 using strange.extensions.injector.api;
@@ -274,6 +275,39 @@ namespace strange.unittests
 			Assert.AreEqual(2, parentModel.Value); //cross context model is changed
 		}
 
+		/// <summary>
+		/// Test that rescanning the same binding does not override a value
+		/// Smaller piece of below test.
+		/// </summary>
+		[Test]
+		public void TestRescanDoesNotOverrideCrossContextValue()
+		{
+			object mockGameObject = new object();
+			TestImplicitBindingContext context = new TestImplicitBindingContext(mockGameObject);
+
+			//Get our binding. It should have value of Runtime Type. It hasn't been instantiated yet.
+			IInjectionBinding binding = context.injectionBinder.GetBinding<TestImplicitBindingClass>();
+			Assert.IsTrue(binding.value is Type);
+
+			//GetInstance. This should set the value to the instantiated class
+			TestImplicitBindingClass instanceValue = context.injectionBinder.GetInstance<TestImplicitBindingClass>();
+			Assert.IsNotNull(instanceValue);
+			IInjectionBinding bindingAfterGetInstance = context.injectionBinder.GetBinding<TestImplicitBindingClass>();
+			Assert.IsTrue(bindingAfterGetInstance.value is TestImplicitBindingClass);
+			Assert.AreSame(bindingAfterGetInstance, binding);
+
+			//Rescan our implicit bindings
+			//Our binding value should remain
+			context.Scan();
+			IInjectionBinding bindingAfterRescan = context.injectionBinder.GetBinding<TestImplicitBindingClass>();
+			Assert.AreSame(bindingAfterRescan, binding); //Should be the same binding, and not override it
+
+			Assert.IsTrue(bindingAfterRescan.value is TestImplicitBindingClass);
+			Assert.AreSame(bindingAfterRescan.value, instanceValue);
+
+
+		}
+
 		//This monster "unit" test confirms that implicit bindings
 		//correctly maintain integrity across Context boundaries.
 		[Test]
@@ -301,6 +335,7 @@ namespace strange.unittests
 
 				//Create each "ContextView" and its Context
 				object mockGameObject = new object ();
+
 				TestImplicitBindingContext context = new TestImplicitBindingContext (mockGameObject);
 				contexts.Add (context);
 
@@ -308,8 +343,9 @@ namespace strange.unittests
 				IInjectionBinding bindingAfterContextCreation = context.injectionBinder.GetBinding<TestImplicitBindingClass> ();
 				object bindingValueAfterContextCreation = bindingAfterContextCreation.value;
 				
-				bool bindingChangedDueToContextCreation = bindingAfterContextCreation != bindingBeforeContextCreation;
+				bool bindingChangedDueToContextCreation = !bindingAfterContextCreation.Equals(bindingBeforeContextCreation);
 				bool bindingValueChangedDueToContextCreation = bindingValueAfterContextCreation != bindingValueBeforeContextCreation;
+
 
 				//due to the weak binding replacement rules, the binding should change every time we scan until we instance
 				Assert.IsFalse (bindingChangedDueToContextCreation && toInstance && !isFirstContextToCallGetInstance);
@@ -317,6 +353,7 @@ namespace strange.unittests
 				//after creating a new context, the value of the binding should only change on the first context
 				//(it was null before that)
 				Assert.IsFalse (bindingValueChangedDueToContextCreation && contextNumber != 1);
+
 
 				if (toInstance)
 				{
@@ -335,6 +372,7 @@ namespace strange.unittests
 						Assert.IsNotNull (instance);
 						Assert.IsNotNull (instance.testImplicitBindingClass);
 					}
+
 				}
 
 				//We inspect the binding and its value after all this mapping/instantiation
@@ -531,8 +569,15 @@ namespace strange.unittests.testimplicitbindingnamespace
 		public TestImplicitBindingContext(object contextView) : base(contextView){}
 		protected override void mapBindings()
 		{
-			implicitBinder.ScanForAnnotatedClasses(new string[]{"strange.unittests.testimplicitbindingnamespace"});
+			base.mapBindings();
+
+			Scan();
 			injectionBinder.Bind<TestImplicitBindingInjectionReceiver>().ToSingleton();
+		}
+
+		public void Scan()
+		{
+			implicitBinder.ScanForAnnotatedClasses(new string[] { "strange.unittests.testimplicitbindingnamespace" });
 		}
 	}
 

--- a/StrangeIoC/scripts/strange/extensions/implicitBind/impl/ImplicitBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/implicitBind/impl/ImplicitBinder.cs
@@ -123,6 +123,7 @@ namespace strange.extensions.implicitBind.impl
 							{
 								bindTypes.Add(type);
 							}
+
 							isCrossContext = isCrossContext || impl.Scope == InjectionBindingScope.CROSS_CONTEXT;
 							name = name ?? impl.Name;
 						}
@@ -182,7 +183,7 @@ namespace strange.extensions.implicitBind.impl
 			//Therefore, ImplementedBy will be overriden by an Implements to that interface.
 
 			IInjectionBinding binding = injectionBinder.Bind(toBind.BindTypes.First());
-			binding.Weak();//SDM2014-0120: added as part of cross-context implicit binding fix (moved from below)
+			binding.Weak();
 
 			for (int i = 1; i < toBind.BindTypes.Count; i++)
 			{
@@ -197,7 +198,6 @@ namespace strange.extensions.implicitBind.impl
 			if (toBind.IsCrossContext) //Bind this to the cross context injector
 				binding.CrossContext();
 
-			//binding.Weak();//SDM2014-0120: removed as part of cross-context implicit binding fix (moved up higher)
 		}
 
 		private sealed class ImplicitBindingVO

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/CrossContextInjectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/CrossContextInjectionBinder.cs
@@ -23,8 +23,6 @@
  * @see strange.extensions.injector.api.ICrossContextInjectionBinder
  */
 
-using System;
-using strange.extensions.injector.impl;
 using strange.extensions.injector.api;
 using strange.framework.api;
 
@@ -38,20 +36,17 @@ namespace strange.extensions.injector.impl
 		{
 		}
 
-		//SDM2014-0120: this function was already here, but the 2 overloads below were added as part of the cross-context implicit binding fix (thus this function was the clue to what
 		public override IInjectionBinding GetBinding<T>()
 		{
 			return GetBinding(typeof(T), null);
 		}
 
 
-		//SDM2014-0120: added as part of cross-Context implicit binding fix
 		public override IInjectionBinding GetBinding<T>(object name)//without this override Binder.GetBinding(object,object) gets called instead of CrossContextInjectionBinder.GetBind
 		{
 			return GetBinding(typeof(T), name);
 		}
 
-		//SDM2014-0120: added as part of cross-Context implicit binding fix
 		public override IInjectionBinding GetBinding(object key)//without this override Binder.GetBinding(object,object) gets called instead of CrossContextInjectionBinder.GetBinding(
 		{
 			return GetBinding(key,null);
@@ -81,11 +76,12 @@ namespace strange.extensions.injector.impl
 				{
 					if (CrossContextBinder == null) //We are a crosscontextbinder
 					{
+
 						base.ResolveBinding(binding, key);
 					}
 					else 
 					{
-						Unbind(key, binding.name); //remove this cross context binding from the local binder
+						base.Unbind(key, binding.name); //remove this cross context binding from ONLY the local binder
 						CrossContextBinder.ResolveBinding(binding, key);
 					}
 				}
@@ -110,16 +106,16 @@ namespace strange.extensions.injector.impl
 
 		public override void Unbind(object key, object name)
 		{
-            IInjectionBinding binding = GetBinding(key, name);
+			IInjectionBinding binding = GetBinding(key, name);
 
-            if (binding != null && 
-                binding.isCrossContext && 
-                CrossContextBinder != null)
-            {
-                CrossContextBinder.Unbind(key, name);
-            }
+			if (binding != null && 
+				binding.isCrossContext && 
+				CrossContextBinder != null)
+			{
+				CrossContextBinder.Unbind(key, name);
+			}
 
-            base.Unbind(key, name);
+			base.Unbind(key, name);
 		}
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/CrossContextInjectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/CrossContextInjectionBinder.cs
@@ -23,6 +23,7 @@
  * @see strange.extensions.injector.api.ICrossContextInjectionBinder
  */
 
+using System;
 using strange.extensions.injector.impl;
 using strange.extensions.injector.api;
 using strange.framework.api;
@@ -105,6 +106,20 @@ namespace strange.extensions.injector.impl
 			{
 				return injector;
 			}
+		}
+
+		public override void Unbind(object key, object name)
+		{
+            IInjectionBinding binding = GetBinding(key, name);
+
+            if (binding != null && 
+                binding.isCrossContext && 
+                CrossContextBinder != null)
+            {
+                CrossContextBinder.Unbind(key, name);
+            }
+
+            base.Unbind(key, name);
 		}
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
@@ -26,7 +26,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using strange.extensions.reflector.api;
 using strange.framework.api;
 using strange.extensions.injector.api;
 using strange.extensions.reflector.impl;
@@ -118,13 +117,11 @@ namespace strange.extensions.injector.impl
 			return base.GetBinding<T> () as IInjectionBinding;
 		}
 
-		//SDM2014-0120: "virtual" added as dictated by changes to CrossContextInjectionBinder in relation to the cross-context implicit binding fix
 		new virtual public IInjectionBinding GetBinding<T>(object name)
 		{
 			return base.GetBinding<T> (name) as IInjectionBinding;
 		}
 
-		//SDM2014-0120: "virtual" added as dictated by changes to CrossContextInjectionBinder in relation to the cross-context implicit binding fix
 		new virtual public IInjectionBinding GetBinding(object key)
 		{
 			return base.GetBinding (key) as IInjectionBinding;

--- a/StrangeIoC/scripts/strange/framework/impl/Binder.cs
+++ b/StrangeIoC/scripts/strange/framework/impl/Binder.cs
@@ -112,7 +112,6 @@
  * ]
  */
 
-using System;
 using System.Collections.Generic;
 using strange.framework.api;
 using MiniJSON;
@@ -372,25 +371,27 @@ namespace strange.framework.impl
 					IBinding existingBinding = dict[bindingName];
 					//if (existingBinding != binding && !existingBinding.isWeak)
 					//SDM2014-01-20: as part of cross-context implicit bindings fix, attempts by a weak binding to replace a non-weak binding are ignored instead of being 
-					if (existingBinding != binding && !existingBinding.isWeak && !binding.isWeak)
+					if (existingBinding != binding)
 					{
-						//register both conflictees
-						registerNameConflict(key, binding, dict[bindingName]);
-						return;
-					}
-
-					if (existingBinding.isWeak)
-					{
-						//SDM2014-01-20: (in relation to the cross-context implicit bindings fix)
-						// 1) if the previous binding is weak and the new binding is not weak, then the new binding replaces the previous;
-						// 2) but if the new binding is also weak, then it only replaces the previous weak binding if the previous binding
-						// has not already been instantiated:
-						if (existingBinding != binding && existingBinding.isWeak && ( !binding.isWeak || existingBinding.value==null || existingBinding.value is System.Type))
+						if (!existingBinding.isWeak && !binding.isWeak)
 						{
+							//register both conflictees
+							registerNameConflict(key, binding, dict[bindingName]);
+						    return;
+						}
+
+						if (existingBinding.isWeak && (!binding.isWeak || existingBinding.value == null || existingBinding.value is System.Type))
+						{
+							//SDM2014-01-20: (in relation to the cross-context implicit bindings fix)
+							// 1) if the previous binding is weak and the new binding is not weak, then the new binding replaces the previous;
+							// 2) but if the new binding is also weak, then it only replaces the previous weak binding if the previous binding
+							// has not already been instantiated:
+
 							//Remove the previous binding.
 							dict.Remove(bindingName);
 						}
 					}
+					
 				}
 			}
 			else
@@ -400,7 +401,7 @@ namespace strange.framework.impl
 			}
 
 			//Remove nulloid bindings
-			if (dict.ContainsKey(BindingConst.NULLOID) && dict[BindingConst.NULLOID] == binding)
+			if (dict.ContainsKey(BindingConst.NULLOID) && dict[BindingConst.NULLOID].Equals(binding) )
 			{
 				dict.Remove (BindingConst.NULLOID);
 			}


### PR DESCRIPTION
This PR fixes unbinding of cross context bindings. Previous PR was incomplete and had a critical bug. It also pointed at maser instead of tip. This PR merges in tip, fixes the bug, cleans up a few stale comments and adds some tests for some of the more complex behaviors.