### PR TITLE
Add params based namespaces in ImplicitBinder

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/implicitBind/api/IImplicitBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/implicitBind/api/IImplicitBinder.cs
@@ -27,7 +27,7 @@ namespace strange.extensions.implicitBind.api
 		/// </summary>
 		/// <param name="usingNamespaces">Array of namespaces. Compared using StartsWith. </param>
 
-		void ScanForAnnotatedClasses(string[] usingNamespaces);
+		void ScanForAnnotatedClasses(params string[] usingNamespaces);
 		Assembly Assembly { get; set; }
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/implicitBind/impl/ImplicitBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/implicitBind/impl/ImplicitBinder.cs
@@ -52,7 +52,7 @@ namespace strange.extensions.implicitBind.impl
 		/// </summary>
 		/// <param name="usingNamespaces">Array of namespaces. Compared using StartsWith. </param>
 
-		public virtual void ScanForAnnotatedClasses(string[] usingNamespaces)
+		public virtual void ScanForAnnotatedClasses(params string[] usingNamespaces)
 		{
 			if (Assembly != null)
 			{


### PR DESCRIPTION
This is done to allow for even the following method calls:

- implicitBinder.ScanForAnnotatedClasses ("Some.Namespace");
- implicitBinder.ScanForAnnotatedClasses (“Some.A”, “Other.B”);

In the previous implementation, one had to write:

implicitBinder.ScanForAnnotatedClasses (new string[] { “Some.A” });

Now both types of formats are supported.

Tests haven’t been added, for the behaviour that params allow is
guaranteed by the language specification itself.

When no namespaces are provided then the behaviour is same as passing
an empty string array.

This closes #170.