### PR TITLE
Promise.Fail listener was not called for already failed promises

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/promise/TestPromise.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/promise/TestPromise.cs
@@ -293,6 +293,14 @@ namespace strange.unittests
 		}
 
 		[Test]
+		public void TestErrorFirst()
+		{
+			promiseOneArg.ReportFail(new Exception(exceptionStr));
+			promiseOneArg.Fail(FailCallback);
+			Assert.AreEqual(currentException.Message, exceptionStr);
+		}
+
+		[Test]
 		public void TestProgressAndError()
 		{
 			float progress = 0.5f;

--- a/StrangeIoC/scripts/strange/extensions/promise/impl/BasePromise.cs
+++ b/StrangeIoC/scripts/strange/extensions/promise/impl/BasePromise.cs
@@ -31,6 +31,7 @@ namespace strange.extensions.promise.impl
 		private event Action<float> OnProgress;
 		private event Action<Exception> OnFail;
 		private event Action OnFinally;
+		private Exception exception;
 
 		public PromiseState State { get; protected set; }
 
@@ -48,6 +49,7 @@ namespace strange.extensions.promise.impl
 
 		public void ReportFail(Exception ex)
 		{
+			exception = ex;
 			State = PromiseState.Failed;
 			if (OnFail != null)
 				OnFail(ex);
@@ -80,7 +82,13 @@ namespace strange.extensions.promise.impl
 
 		public IBasePromise Fail(Action<Exception> listener)
 		{
-			OnFail = AddUnique<Exception>(OnFail, listener);
+			if (Failed)
+			{
+				listener(exception);
+				Finally();
+			}
+			else
+				OnFail = AddUnique<Exception>(OnFail, listener);
 			return this;
 		}
 


### PR DESCRIPTION
To simplify error handling, Promise.Fail listener should be called immediately if the promise was already failed.