### PR TITLE
Add object based Bind methods to IMediationBinder

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/mediation/api/IMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/api/IMediationBinder.cs
@@ -77,8 +77,14 @@ namespace strange.extensions.mediation.api
 		/// Recast binding as IMediationBinding.
 		new IMediationBinding Bind<T> ();
 
+		/// Recast binding as IMediationBinding.
+		new IMediationBinding Bind(object value);
+
 		/// Porcelain for Bind<T> providing a little extra clarity and security.
 		IMediationBinding BindView<T> ();
+
+		/// Precelain for Bind(object value) providing a little extra clarity and security
+		IMediationBinding BindView(object value);
 	}
 }
 

--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/AbstractMediationBinder.cs
@@ -215,9 +215,19 @@ namespace strange.extensions.mediation.impl
 			return base.Bind<T> () as IMediationBinding;
 		}
 
+		new public IMediationBinding Bind(object key)
+		{
+			return base.Bind(key) as IMediationBinding;
+		}
+
 		public IMediationBinding BindView<T>()
 		{
 			return base.Bind<T> () as IMediationBinding;
+		}
+
+		public IMediationBinding BindView(object key)
+		{
+			return base.Bind(key) as IMediationBinding;
 		}
 
 		/// Creates and registers one or more Mediators for a specific View instance.


### PR DESCRIPTION
This pull request is adding the Bind method which takes an object to IMediationBinder (and the BindView method which takes an object).

Currently if you try to call Bind(object value) on an instance of mediation binder, you are returned an IBinding instead of IMediationBinding and have to manually perform a cast in order to call a mediation method i.e. ToAbstraction.

This means if you have any bindings created without using generics (for example using reflection at startup) it's not pretty to create those bindings.

I think this should be accepted, because other binders have a similar Bind(object value) method, I think it makes sense that all binders should include this method.