### PR TITLE
Fix for Generic Signal ListensTo Problem on Issue#205

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
@@ -102,7 +102,8 @@ namespace strange.extensions.mediation
 		{
 			if (signal.GetType().BaseType.IsGenericType)
 			{
-				signal.listener = Delegate.CreateDelegate(signal.listener.GetType(), mediator, method); //e.g. Signal<T>, Signal<T,U> etc.
+				Delegate toAdd = Delegate.CreateDelegate(signal.listener.GetType(), mediator, method); //e.g. Signal<T>, Signal<T,U> etc.
+				signal.listener = Delegate.Combine(signal.listener, toAdd);
 			}
 			else
 			{


### PR DESCRIPTION
Rather than right away assigning it to *signal.listener*, combining delegates prevents previously assigned delegate to get overridden with the last one.

Used a similar naming with *RemoveDelegate* method for consistency.