### PR TITLE
Feature promise reset

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/promise/TestPromise.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/promise/TestPromise.cs
@@ -673,6 +673,31 @@ namespace strange.unittests
 			Assert.AreEqual(0, value);
 		}
 
+		[Test]
+		public void TestResetPromise()
+		{
+			int res = 0;
+			promiseOneArg.Dispatch(1);
+			promiseOneArg.Then(i => res = i);
+			Assert.AreEqual(1, res);
+
+			res = 0;
+			var res2 = -1;
+
+			// After reset dispatch is doing nothing
+			// And res will not changes anymore.
+			promiseOneArg.Reset();
+			promiseOneArg.Then(i => res2 = i);
+			Assert.AreEqual(-1, res2);
+			Assert.AreEqual(0, res);
+
+			// Dispatch again and things'll change
+			promiseOneArg.Dispatch(2);
+			Assert.AreEqual(2, res2);
+			Assert.AreEqual(0, res);
+		}
+
+
 #region Callbacks
 		
 		private void NoArgCallback()

--- a/StrangeIoC/scripts/strange/extensions/promise/api/IPromise.cs
+++ b/StrangeIoC/scripts/strange/extensions/promise/api/IPromise.cs
@@ -99,6 +99,11 @@ namespace strange.extensions.promise.api
 		int ListenerCount();
 
 		BasePromise.PromiseState State { get; }
+
+		/// <summary>
+		/// Removes all listeners, defaults the dispatched value, and sets the state to Pending
+		/// </summary>
+		void Reset();
 	}
 	public interface IPromise : IBasePromise
 	{

--- a/StrangeIoC/scripts/strange/extensions/promise/impl/BasePromise.cs
+++ b/StrangeIoC/scripts/strange/extensions/promise/impl/BasePromise.cs
@@ -102,6 +102,12 @@ namespace strange.extensions.promise.impl
 			return this;
 		}
 
+		public virtual void Reset()
+		{
+			RemoveAllListeners();
+			this.State = BasePromise.PromiseState.Pending;
+		}
+
 		/// <summary>
 		/// Trigger Finally callbacks
 		/// </summary>

--- a/StrangeIoC/scripts/strange/extensions/promise/impl/Promise.cs
+++ b/StrangeIoC/scripts/strange/extensions/promise/impl/Promise.cs
@@ -136,6 +136,13 @@ namespace strange.extensions.promise.impl
 		{
 			return Listener == null ? 0 : Listener.GetInvocationList().Length;
 		}
+
+		public override void Reset()
+		{
+			base.Reset();
+			this.t = default(T);
+		}
+
 		private void CallListener()
 		{
 			if (Listener != null)
@@ -199,6 +206,14 @@ namespace strange.extensions.promise.impl
 		{
 			return Listener == null ? 0 : Listener.GetInvocationList().Length;
 		}
+
+		public override void Reset()
+		{
+			base.Reset();
+			this.t = default(T);
+			this.u = default(U);
+		}
+
 		private void CallListener()
 		{
 			if (Listener != null)
@@ -273,6 +288,14 @@ namespace strange.extensions.promise.impl
 		{
 			return Listener == null ? 0 : Listener.GetInvocationList().Length;
 		}
+		public override void Reset()
+		{
+			base.Reset();
+			this.t = default(T);
+			this.u = default(U);
+			this.v = default(V);
+		}
+
 		private void CallListener()
 		{
 			if (Listener != null)
@@ -350,6 +373,16 @@ namespace strange.extensions.promise.impl
 		{
 			return Listener == null ? 0 : Listener.GetInvocationList().Length;
 		}
+
+		public override void Reset()
+		{
+			base.Reset();
+			this.t = default(T);
+			this.u = default(U);
+			this.v = default(V);
+			this.w = default(W);
+		}
+
 		private void CallListener()
 		{
 			if (Listener != null)

--- a/StrangeIoC/scripts/strange/extensions/signal/impl/Promise.cs.meta
+++ b/StrangeIoC/scripts/strange/extensions/signal/impl/Promise.cs.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: e39226ddb1270c5479ba0af9f12bfd6f
-MonoImporter:
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 


### PR DESCRIPTION
To recycle promises, e.g. via pools, promises have to be resettable to original state. This pull request does just that.
