### PR TITLE
ListensTo Attribute Usage On Generic Signals throws Exception

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Reflection;
+using System.Linq.Expressions;
 using strange.extensions.mediation.api;
 using strange.extensions.mediation.impl;
 using strange.extensions.reflector.api;
@@ -102,7 +103,18 @@ namespace strange.extensions.mediation
 		{
 			if (signal.GetType().BaseType.IsGenericType)
 			{
-				signal.listener = Delegate.CreateDelegate(signal.listener.GetType(), mediator, method); //e.g. Signal<T>, Signal<T,U> etc.
+				Type listenerType;
+				if(signal.listener == null)
+				{
+					Type[] generics = signal.GetType().BaseType.GetGenericArguments();
+					listenerType = Expression.GetActionType(generics);
+				}
+				else
+				{
+					listenerType = signal.listener.GetType();
+				}
+				Delegate toAdd = Delegate.CreateDelegate(listenerType, mediator, method); //e.g. Signal<T>, Signal<T,U> etc.
+				signal.listener = Delegate.Combine(signal.listener, toAdd);
 			}
 			else
 			{


### PR DESCRIPTION
If you try to assign a delegate to a generic signal listener which does not have an already existing listener, `signal.listener.GetType()` will throws a `NullReferenceException` while we are trying to define the Type of our new Delegate.

Fix just extracts the signals generics and creates a delegate with the appropriate action type.