### PR TITLE
Added MediateAs Attribute

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/mediation/api/MediateAsAttribute.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/api/MediateAsAttribute.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright 2013 ThirdMotion, Inc.
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *		Unless required by applicable law or agreed to in writing, software
+ *		distributed under the License is distributed on an "AS IS" BASIS,
+ *		WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *		See the License for the specific language governing permissions and
+ *		limitations under the License.
+ */
+
+/**
+ * @class BindAs
+ * 
+ * The `[BindAs]` attribute allows a class to be recognized as one of it's implementing or base types.
+ * 
+ * Example:
+
+		[BindAs(typeof(IMainView))]
+		public class MainView : View, IMainView {
+			...
+		}
+*
+*  This is useful in using the mediationBinder in a more generic fashion to allow for better abstraction
+*  at runtime.
+*  
+*  Example:
+
+		mediationBinder.Bind<MainView>().To<MainViewMediator>();
+
+		// now bceomes
+		mediationBinder.Bind<IMainView>().To<MainViewMediator>();
+**/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace strange.extensions.mediation.api
+{
+	[AttributeUsage(AttributeTargets.Property,
+		AllowMultiple = false,
+		Inherited = true)]
+	public class MediateAs : Attribute
+	{
+		public MediateAs(Type t) {
+			MediateAsType = t;
+		}
+
+		public Type MediateAsType { get; set; }
+	}
+}

--- a/StrangeIoC/scripts/strange/extensions/mediation/api/MediationExceptionType.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/api/MediationExceptionType.cs
@@ -47,6 +47,12 @@ namespace strange.extensions.mediation.api
 
 		/// View bound to abstraction that View doesn't actually extend/implement
 		VIEW_NOT_ASSIGNABLE,
+
+		/// The BindAs attribute has been defined more than once for a class
+		MULTIPLE_BINDAS_ATTRIBUTE_DEFINITIONS,
+
+		/// The BindAs attribute specifies a type that the class does not derive from or implement.
+		BINDAS_TYPE_NOT_IMPLEMENTED,
 	}
 }
 


### PR DESCRIPTION
The MediateAs attribute allows a developer to specify the base type of a
view that it would like to use for registration with the mediation
binder. This is useful for mediating a view by an interface or base
type.