### PR TITLE
EventMediator converted to generic class, it will take type of the bi…

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/mediation/impl/EventMediator.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/impl/EventMediator.cs
@@ -27,11 +27,18 @@ using strange.extensions.dispatcher.eventdispatcher.api;
 
 namespace strange.extensions.mediation.impl
 {
-	public class EventMediator : Mediator
-	{
+    public class EventMediator<T> : Mediator where T : EventView
+    {
 		[Inject(ContextKeys.CONTEXT_DISPATCHER)]
 		public IEventDispatcher dispatcher{ get; set;}
 
-	}
+        [Inject]
+        public T view { get; set; }
+
+        protected void DispatchToContext(object evt)
+        {
+            view.dispatcher.AddListener(evt, (IEvent payload) => { dispatcher.Dispatch(evt, payload); });
+        }
+    }
 }
 


### PR DESCRIPTION
**EventMediator and EventView releationship simplified as in the below example**
```
public class AMediator : EventMediator<AView>
{
    public override void OnRegister()
    {
        DispatchToContext(AEvents.Joined); 
        view.OnSomething();
    }
}

public class AView : EventView
{
    public void OnSomething(object)
    {
        dispatcher.Dispatch(AEvents.Joined, payload);
    }
}
```