### PR TITLE
Pass first context's ReflectionBinder cross context

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/context/impl/CrossContext.cs
+++ b/StrangeIoC/scripts/strange/extensions/context/impl/CrossContext.cs
@@ -31,6 +31,7 @@ using strange.extensions.dispatcher.api;
 using strange.extensions.injector.api;
 using strange.extensions.injector.impl;
 using strange.framework.api;
+using UnityEngine;
 
 namespace strange.extensions.context.impl
 {
@@ -79,7 +80,7 @@ namespace strange.extensions.context.impl
 			base.addCoreComponents();
 			if (injectionBinder.CrossContextBinder == null)  //Only null if it could not find a parent context / firstContext
 			{
-				injectionBinder.CrossContextBinder = new CrossContextInjectionBinder();
+				injectionBinder.CrossContextBinder = new CrossContextInjectionBinder(injectionBinder.injector.reflector);
 			}
 
 			if (firstContext == this)
@@ -120,7 +121,7 @@ namespace strange.extensions.context.impl
 		virtual public void AssignCrossContext(ICrossContextCapable childContext)
 		{
 			childContext.crossContextDispatcher = crossContextDispatcher;
-			childContext.injectionBinder.CrossContextBinder = injectionBinder.CrossContextBinder;
+			childContext.injectionBinder = new CrossContextInjectionBinder(injectionBinder.CrossContextBinder);
 		}
 
 		virtual public void RemoveCrossContext(ICrossContextCapable childContext)

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/CrossContextInjectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/CrossContextInjectionBinder.cs
@@ -24,6 +24,7 @@
  */
 
 using strange.extensions.injector.api;
+using strange.extensions.reflector.api;
 using strange.framework.api;
 
 namespace strange.extensions.injector.impl
@@ -34,14 +35,22 @@ namespace strange.extensions.injector.impl
 
 		public CrossContextInjectionBinder() : base()
 		{
-		}
+        }
+
+        public CrossContextInjectionBinder(IReflectionBinder reflector) : base( reflector)
+        {
+        }
+
+        public CrossContextInjectionBinder(IInjectionBinder crossContextBinder) : this(crossContextBinder.injector.reflector)
+        {
+            CrossContextBinder = crossContextBinder;
+        }
 
 		public override IInjectionBinding GetBinding<T>()
 		{
 			return GetBinding(typeof(T), null);
 		}
-
-
+        
 		public override IInjectionBinding GetBinding<T>(object name)//without this override Binder.GetBinding(object,object) gets called instead of CrossContextInjectionBinder.GetBind
 		{
 			return GetBinding(typeof(T), name);
@@ -51,8 +60,7 @@ namespace strange.extensions.injector.impl
 		{
 			return GetBinding(key,null);
 		}
-
-
+        
 		public override IInjectionBinding GetBinding(object key, object name)
 		{
 			IInjectionBinding binding = base.GetBinding(key, name) as IInjectionBinding;

--- a/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/injector/impl/InjectionBinder.cs
@@ -28,6 +28,7 @@ using System.Collections.Generic;
 using System.Linq;
 using strange.framework.api;
 using strange.extensions.injector.api;
+using strange.extensions.reflector.api;
 using strange.extensions.reflector.impl;
 using strange.framework.impl;
 
@@ -38,12 +39,16 @@ namespace strange.extensions.injector.impl
 		private IInjector _injector;
 		protected Dictionary<Type, Dictionary<Type, IInjectionBinding>> suppliers = new Dictionary<Type, Dictionary<Type, IInjectionBinding>>();
 
-		public InjectionBinder ()
+		public InjectionBinder () : this(new ReflectionBinder())
 		{
-			injector = new Injector ();
-			injector.binder = this;
-			injector.reflector = new ReflectionBinder();
 		}
+
+        public InjectionBinder(IReflectionBinder reflector)
+        {
+            injector = new Injector();
+            injector.binder = this;
+            injector.reflector = reflector ?? new ReflectionBinder();
+        }
 
 		public object GetInstance(Type key)
 		{


### PR DESCRIPTION
I tried to follow a similar process to how the CrossContextBinder was being passed along from the firstContext. This should ensure that all classes are only mapped once as long as the firstContext stays the same.