### PR TITLE
Fixing bug when using implicit binders when StrangeIoC is contained within a Unity 2017 (and higher) Assembly Definition file.

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/implicitBind/api/IImplicitBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/implicitBind/api/IImplicitBinder.cs
@@ -28,6 +28,6 @@ namespace strange.extensions.implicitBind.api
 		/// <param name="usingNamespaces">Array of namespaces. Compared using StartsWith. </param>
 
 		void ScanForAnnotatedClasses(params string[] usingNamespaces);
-		Assembly Assembly { get; set; }
+		Assembly[] Assemblies { get; set; }
 	}
 }

--- a/StrangeIoC/scripts/strange/extensions/implicitBind/impl/ImplicitBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/implicitBind/impl/ImplicitBinder.cs
@@ -36,14 +36,14 @@ namespace strange.extensions.implicitBind.impl
 		public IMediationBinder mediationBinder { get; set; }
 
 
-		//Hold a copy of the assembly so we aren't retrieving this multiple times. 
-		public Assembly Assembly { get; set; }
+		//Hold a copy of the domain assemblies so we aren't retrieving them multiple times. 
+		public Assembly[] Assemblies { get; set; }
 
 
 		[PostConstruct]
 		public void PostConstruct()
 		{
-			Assembly = Assembly.GetExecutingAssembly();
+			Assemblies = AppDomain.CurrentDomain.GetAssemblies();
 		}
 
 		/// <summary>
@@ -54,10 +54,10 @@ namespace strange.extensions.implicitBind.impl
 
 		public virtual void ScanForAnnotatedClasses(params string[] usingNamespaces)
 		{
-			if (Assembly != null)
+			if (Assemblies != null)
 			{
-
-				IEnumerable<Type> types = Assembly.GetExportedTypes();
+				
+				IEnumerable<Type> types = Assemblies.SelectMany(a => a.GetExportedTypes());
 
 				List<Type> typesInNamespaces = new List<Type>();
 				int namespacesLength = usingNamespaces.Length;


### PR DESCRIPTION
# Overview
In Unity 2017.3 and higher, I have observed issues using Assembly Definitions to contain StrangeIoC alongside of Contexts that utilize `ImplicitBinders`, specifically, `ImplicitBinders.ScanForAnnotatedClasses()`.

The bug is caused by placing StrangeIoC into an Assembly Definition that does not include the annotated classes you wish to find with `ScanForAnnotatedClasses`. The solution is to instead of searching through the executing assembly, search through all assemblies in the app's current domain. I do not know if this is the absolute best way, and I am looking for feedback. If it is rock solid, by all means, use it!

# Reproduction Steps
1. Create a new project with StrangeIoC installed, and with scripts that do not share namespaces or folders with StrangeIoC.
2. Create an Assembly Definition for StrangeIoC.
3. Optionally, create Assembly Definitions for other collections of scripts.
4. Create at least one script annotated for implicit binding. Configuration does not matter.
5. Create a context attempting to capture the namespace with an annotated class for implicit binding. Make sure this class is not in the same Assembly Definition or namespace as StrangeIoC.
6. Create a class that injects this newly made implicit dependency.
7. Run game.

# Expected Behavior
Scene should run, and implicit binding should silently succeed.

# Observed Behavior
StrangeIoC throws an error at runtime, stating that a injection of a null binding was attempted.
