### PR TITLE
Fixing a bug where firstContext was not being properly reset on Context creation after contextView destruction.

### DIFF
--- a/StrangeIoC/scripts/strange/.tests/extensions/context/TestContext.cs
+++ b/StrangeIoC/scripts/strange/.tests/extensions/context/TestContext.cs
@@ -3,6 +3,7 @@ using strange.extensions.context.impl;
 using strange.extensions.injector.impl;
 using strange.extensions.injector.api;
 using strange.extensions.context.api;
+using UnityEngine;
 
 namespace strange.unittests
 {
@@ -34,6 +35,20 @@ namespace strange.unittests
 		{
 			Context context = new Context (view);
 			Assert.AreEqual (view, context.contextView);
+		}
+
+		[Test]
+		public void TestNewFirstContext()
+		{
+			// https://answers.unity.com/questions/586144/destroyed-monobehaviour-not-comparing-to-null.html
+			UnityEngine.Object gameView = new UnityEngine.Object();
+
+			Context contextOld = new Context (gameView);
+			UnityEngine.Object.Destroy(contextOld.contextView as UnityEngine.Object);
+
+			Context contextNew = new Context (view);
+			Assert.AreEqual	(contextNew, Context.firstContext);
+			Assert.AreEqual (view, Context.firstContext.GetContextView());
 		}
 
 		[Test]

--- a/StrangeIoC/scripts/strange/extensions/context/impl/Context.cs
+++ b/StrangeIoC/scripts/strange/extensions/context/impl/Context.cs
@@ -49,8 +49,11 @@ namespace strange.extensions.context.impl
 
 		public Context(object view, ContextStartupFlags flags)
 		{
-			//If firstContext was unloaded, the contextView will be null. Assign the new context as firstContext.
-			if (firstContext == null || firstContext.GetContextView() == null)
+			// If firstContext was unloaded, the contextView will be null. Assign the new context as firstContext.
+			// The additional Equals(null) check is in the case the contextView GameObject is marked for destruction without
+			// actually being destroyed yet. All three conditions, in this order, are valid reasons to set firstContext.
+			// https://answers.unity.com/questions/586144/destroyed-monobehaviour-not-comparing-to-null.html
+			if (firstContext == null || firstContext.GetContextView() == null || firstContext.GetContextView().Equals(null))
 			{
 				firstContext = this;
 			}


### PR DESCRIPTION
# Overview
In throwing StrangeIOC against the wall with a gauntlet of tests, I discovered that the destruction of the contextView of a Context did not necessarily set the result of GetContextView() as null. This obviously made it hard for Strange to know that its conditions have been met to set a new firstContext.

# Reading
Please review [this Unity Answers link](https://answers.unity.com/questions/586144/destroyed-monobehaviour-not-comparing-to-null.html) for someone who ran into a similar situation as my own.

# Expected Behavior
Destroying a GameObject which a Context is attached to should properly mark the Context's contextView as null, which should in turn, upon creating a new Context, make that context the new firstContext.

# Reproduction
I've provided a test case in this pull request. Simply remove the expression added in Context.cs to watch it fail.

# Solution
I've added a third expression to check `firstContext.GetContextView().Equals(null)`. This resolves the issue and correctly works with the Destroy interactions on UnityEngine Objects.
