### PR TITLE
Fix Deeper Inheritance Breaks SignalMediationBinder.AssignDelegate

### DIFF
--- a/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
+++ b/StrangeIoC/scripts/strange/extensions/mediation/SignalMediationBinder.cs
@@ -94,15 +94,16 @@ namespace strange.extensions.mediation
 		/// Apply ListensTo delegates
 		protected void AssignDelegate(object mediator, ISignal signal, MethodInfo method)
 		{
-			if (signal.GetType().BaseType.IsGenericType)
+			switch(signal.listener.Method.GetParameters().Length)
 			{
-				var toAdd = Delegate.CreateDelegate(signal.listener.GetType(), mediator, method); //e.g. Signal<T>, Signal<T,U> etc.
-				signal.listener = Delegate.Combine(signal.listener, toAdd);
-			}
-			else
-			{
-				((Signal)signal).AddListener((Action)Delegate.CreateDelegate(typeof(Action), mediator, method)); //Assign and cast explicitly for Type == Signal case
-			}
+				case 0:
+                    ((Signal)signal).AddListener((Action)Delegate.CreateDelegate(typeof(Action), mediator, method)); //Assign and cast explicitly for Type == Signal case
+                    break;
+                default:
+                    var toAdd = Delegate.CreateDelegate(signal.listener.GetType(), mediator, method); //e.g. Signal<T>, Signal<T,U> etc.
+                    signal.listener = Delegate.Combine(signal.listener, toAdd);
+                    break;
+            }
 		}
 	}
 }


### PR DESCRIPTION
SignalMediationBinder.AssignDelegate doesn't handle the case where the signal generic type is more than 1 level of inheritance down.

for example:
```
public class MyBaseSignal : Signal<int, string> {}
public class MyDerivedSignal : MyBaseSignal {}
```

`AssignDelegate` treats `MyDerivedSignal` as a signal without parameters.

Checking the length of the parameters in the listener won't rely on inheritance hierarchy.